### PR TITLE
Add policy schema for network allowlists (m1.1)

### DIFF
--- a/docs/plan/milestones/m1-devcontainer-template/tasks/m1.1-policy-schema/task.md
+++ b/docs/plan/milestones/m1-devcontainer-template/tasks/m1.1-policy-schema/task.md
@@ -1,0 +1,59 @@
+# m1.1-policy-schema
+
+Define the YAML schema for policy files that control network allowlists.
+
+## Goal
+
+Create a policy.yaml format that:
+- Groups related domains into "services" with special handling
+- Keeps plain "domains" for project-specific additions
+- Is simple enough to edit by hand
+
+## Schema Design
+
+```yaml
+egress:
+  services:
+    - claude-code
+    - github
+    - vscode
+  # domains are optional, for project-specific additions
+  # domains:
+  #   - registry.npmjs.org
+
+# Future sections (not yet implemented):
+# ingress:
+#   ports: [8080]
+# mounts:
+#   blocked: [~/.aws/credentials]
+```
+
+### Egress Services
+
+| Service | Domains | Resolution |
+|---------|---------|------------|
+| claude-code | api.anthropic.com, sentry.io, statsig.anthropic.com, statsig.com | DNS resolution |
+| github | web, api, git endpoints | Fetches IP ranges from api.github.com/meta, aggregates into CIDR blocks |
+| vscode | marketplace.visualstudio.com, mobile.events.data.microsoft.com, vscode.blob.core.windows.net, update.code.visualstudio.com | DNS resolution |
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| egress.services | list of strings | No | Known services with predefined domain lists |
+| egress.domains | list of strings | No | Additional domains to allow (DNS resolution at startup) |
+
+## Deliverables
+
+- [x] `docs/policy/schema.md` - Schema documentation
+- [x] `docs/policy/example.yaml` - Example policy file with comments
+
+## Out of Scope
+
+- Firewall script changes (m1.4)
+- Path/method filtering (m5)
+- JSON Schema for IDE validation
+
+## Status
+
+Complete. Schema documented, example created. Ready for m1.4 to implement firewall parsing.

--- a/docs/policy/example.yaml
+++ b/docs/policy/example.yaml
@@ -1,0 +1,26 @@
+# policy.yaml
+#
+# Sandbox policy for agent-sandbox containers.
+# See docs/policy/schema.md for full documentation.
+
+# Egress controls outbound network traffic.
+# The firewall blocks all outbound except to these destinations.
+egress:
+  # Services are predefined domain groups.
+  # Available: claude-code, github, vscode
+  services:
+    - claude-code  # Anthropic API and telemetry
+    - github       # GitHub web, API, git (IPs from api.github.com/meta)
+    - vscode       # VS Code marketplace and updates
+
+  # Additional domains (resolved via DNS at startup).
+  # domains:
+  #   - registry.npmjs.org
+  #   - pypi.org
+
+# Future sections (not yet implemented):
+# ingress:
+#   ports: [8080, 3000]
+# mounts:
+#   readonly: [~/.ssh]
+#   blocked: [~/.aws/credentials]

--- a/docs/policy/schema.md
+++ b/docs/policy/schema.md
@@ -1,0 +1,93 @@
+# Policy Schema
+
+Policy files configure sandbox restrictions for agent-sandbox containers. Currently supports outbound network allowlists, with future support planned for ingress rules, port forwarding, and mount restrictions.
+
+## Format
+
+```yaml
+egress:
+  services:
+    - claude-code
+    - github
+    - vscode
+  domains:
+    - registry.npmjs.org
+    - your-internal-api.example.com
+
+# Future sections (not yet implemented):
+# ingress:
+#   ports: [8080, 3000]
+# mounts:
+#   readonly: [~/.ssh]
+#   blocked: [~/.aws/credentials]
+```
+
+## Egress
+
+Controls outbound network traffic. The firewall blocks all outbound except to destinations listed here.
+
+### egress.services
+
+A list of predefined service names. Each service expands to a set of domains with appropriate resolution logic.
+
+| Service | Domains | Notes |
+|---------|---------|-------|
+| `claude-code` | Anthropic API and telemetry | api.anthropic.com, sentry.io, statsig.anthropic.com, statsig.com |
+| `github` | GitHub web, API, and git endpoints | IPs fetched from api.github.com/meta and aggregated into CIDR blocks |
+| `vscode` | VS Code marketplace and telemetry | marketplace.visualstudio.com, mobile.events.data.microsoft.com, vscode.blob.core.windows.net, update.code.visualstudio.com |
+
+### egress.domains
+
+A list of additional domain names to allow. Each domain is resolved via DNS at container startup, and the resulting IPs are added to the allowlist.
+
+Use this for:
+- Package registries (e.g., registry.npmjs.org, pypi.org)
+- Internal APIs your project needs
+- Any domain not covered by a service
+
+## Examples
+
+### Minimal policy (Claude Code only)
+
+```yaml
+egress:
+  services:
+    - claude-code
+    - github
+```
+
+### With VS Code devcontainer support
+
+```yaml
+egress:
+  services:
+    - claude-code
+    - github
+    - vscode
+```
+
+### Adding project-specific domains
+
+```yaml
+egress:
+  services:
+    - claude-code
+    - github
+    - vscode
+  domains:
+    - api.stripe.com          # payment processing
+    - pypi.org                # Python packages
+    - registry.npmjs.org      # npm packages
+```
+
+## How It Works
+
+At container startup, `init-firewall.sh` reads the policy file and:
+
+1. For each service in `egress.services`, resolves the associated domains (or fetches IP ranges for github)
+2. For each domain in `egress.domains`, performs DNS resolution
+3. Adds all IPs to an ipset
+4. Configures iptables to allow only traffic to IPs in the set
+5. Verifies the firewall by checking that example.com is blocked
+
+Changes to the policy require rebuilding the container.


### PR DESCRIPTION
## Summary

- Define YAML schema for configuring sandbox restrictions
- `egress.services`: predefined service groups (claude-code, github, vscode)
- `egress.domains`: additional domains for project-specific needs
- Structure supports future sections (ingress, mounts)

## Files

- `docs/policy/schema.md` - Schema documentation
- `docs/policy/example.yaml` - Example policy file
- `docs/plan/milestones/m1-devcontainer-template/tasks/m1.1-policy-schema/task.md` - Task record