### PR TITLE
Add GitHub Actions workflow and update template for GHCR (m2)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,129 @@
+name: Build and Push Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+      - '.github/workflows/build-images.yml'
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  BASE_IMAGE_NAME: ${{ github.repository_owner }}/agent-sandbox-base
+  CLAUDE_IMAGE_NAME: ${{ github.repository_owner }}/agent-sandbox-claude
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./images/base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output digest
+        run: echo "Base image digest - ${{ steps.build.outputs.digest }}"
+
+  build-claude:
+    runs-on: ubuntu-latest
+    needs: build-base
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.CLAUDE_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./images/agents/claude
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output digest
+        run: echo "Claude image digest - ${{ steps.build.outputs.digest }}"
+
+  summary:
+    runs-on: ubuntu-latest
+    needs: [build-base, build-claude]
+    steps:
+      - name: Summary
+        run: |
+          echo "## Image Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | Digest |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| agent-sandbox-base | \`${{ needs.build-base.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| agent-sandbox-claude | \`${{ needs.build-claude.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -45,17 +45,13 @@ colima start --cpu 4 --memory 8 --disk 60
 
 If you previously used Docker Desktop, set your Docker credential helper to `osxkeychain` (not `desktop`) in `~/.docker/config.json`.
 
-### 2. Build the docker images
+### 2. Copy template to your project
+
+Clone the repo to get the template files (images are pulled from GHCR automatically):
 
 ```bash
 git clone https://github.com/mattolson/agent-sandbox.git
-cd agent-sandbox
-./images/build.sh
 ```
-
-This builds `agent-sandbox-base:local` and `agent-sandbox-claude:local`.
-
-### 3. Choose your mode
 
 #### Option A: Devcontainer (VS Code)
 
@@ -77,7 +73,7 @@ docker compose up -d
 docker compose exec agent zsh
 ```
 
-### 4. Authenticate Claude Code (first time only)
+### 3. Authenticate Claude Code (first time only)
 
 From your **host terminal** (not the VS Code integrated terminal):
 
@@ -98,7 +94,7 @@ This triggers the OAuth flow:
 
 Credentials persist in a Docker volume. You only need to do this once per project.
 
-### 5. Run Claude Code
+### 4. Run Claude Code
 
 From inside the container:
 

--- a/devcontainer/templates/minimal/claude/.devcontainer/Dockerfile
+++ b/devcontainer/templates/minimal/claude/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
 # Claude Code Sandbox
 #
-# Requires: Build images first from the agent-sandbox repo:
-#   git clone https://github.com/mattolson/agent-sandbox.git
-#   cd agent-sandbox && ./images/build.sh
+# Uses published image from GitHub Container Registry.
+# For reproducibility, pin to a specific digest:
+#   ARG BASE_IMAGE=ghcr.io/mattolson/agent-sandbox-claude@sha256:<digest>
 #
-# Once images are published to GHCR (m2), this will use:
-#   ARG BASE_IMAGE=ghcr.io/mattolson/agent-sandbox-claude@sha256:...
+# For local development, override with:
+#   docker build --build-arg BASE_IMAGE=agent-sandbox-claude:local .
 
-ARG BASE_IMAGE=agent-sandbox-claude:local
+ARG BASE_IMAGE=ghcr.io/mattolson/agent-sandbox-claude:latest
 FROM ${BASE_IMAGE}
 
 # Copy project policy (customize policy.yaml to add domains)

--- a/devcontainer/templates/minimal/claude/README.md
+++ b/devcontainer/templates/minimal/claude/README.md
@@ -2,17 +2,7 @@
 
 Run Claude Code in a network-locked container with egress restricted to allowed domains only.
 
-## Prerequisites
-
-Build the base images (one-time setup):
-
-```bash
-git clone https://github.com/mattolson/agent-sandbox.git
-cd agent-sandbox
-./images/build.sh
-```
-
-This creates `agent-sandbox-base:local` and `agent-sandbox-claude:local`.
+Images are published to GitHub Container Registry and pulled automatically.
 
 ## Quick Start
 
@@ -152,3 +142,48 @@ sudo iptables -L -n
 ```
 
 Should show DROP policies with an ipset match rule. If not, check `postStartCommand` (devcontainer) or entrypoint logs (compose).
+
+## Image Versioning
+
+By default, the template uses `:latest` which tracks the most recent build. For reproducibility, pin to a specific digest.
+
+### Finding the current digest
+
+```bash
+docker pull ghcr.io/mattolson/agent-sandbox-claude:latest
+docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/mattolson/agent-sandbox-claude:latest
+```
+
+### Pinning in devcontainer
+
+Edit `.devcontainer/Dockerfile`:
+
+```dockerfile
+ARG BASE_IMAGE=ghcr.io/mattolson/agent-sandbox-claude@sha256:<digest>
+```
+
+### Pinning in compose
+
+Edit `docker-compose.yml`:
+
+```yaml
+image: ghcr.io/mattolson/agent-sandbox-claude@sha256:<digest>
+```
+
+### Local development
+
+To use locally-built images instead of GHCR:
+
+```bash
+# Build images
+git clone https://github.com/mattolson/agent-sandbox.git
+cd agent-sandbox && ./images/build.sh
+
+# Override in devcontainer (rebuild required)
+# Edit .devcontainer/Dockerfile:
+ARG BASE_IMAGE=agent-sandbox-claude:local
+
+# Override in compose
+# Edit docker-compose.yml:
+image: agent-sandbox-claude:local
+```

--- a/devcontainer/templates/minimal/claude/docker-compose.yml
+++ b/devcontainer/templates/minimal/claude/docker-compose.yml
@@ -1,18 +1,20 @@
 # Claude Code Sandbox - Docker Compose mode
 #
-# Requires: Build images first from the agent-sandbox repo:
-#   git clone https://github.com/mattolson/agent-sandbox.git
-#   cd agent-sandbox && ./images/build.sh
-#
 # Usage:
 #   docker compose up -d
 #   docker compose exec agent zsh
 #   # Run claude inside the container
 #   docker compose down
+#
+# For reproducibility, pin to a specific digest:
+#   image: ghcr.io/mattolson/agent-sandbox-claude@sha256:<digest>
+#
+# For local development:
+#   image: agent-sandbox-claude:local
 
 services:
   agent:
-    image: agent-sandbox-claude:local
+    image: ghcr.io/mattolson/agent-sandbox-claude:latest
     container_name: claude-sandbox
     cap_add:
       - NET_ADMIN

--- a/docs/plan/milestones/m2-images/milestone.md
+++ b/docs/plan/milestones/m2-images/milestone.md
@@ -1,0 +1,113 @@
+# m2-images
+
+Build and publish images to GitHub Container Registry so users don't need to build locally.
+
+## Goals
+
+- Set up GitHub Actions to build and publish images
+- Update template to use published images with digest pinning
+- Document image update process
+
+## Current State
+
+From M1:
+- `images/base/Dockerfile` - base image with tools, firewall, zsh
+- `images/agents/claude/Dockerfile` - extends base with Claude Code
+- `images/build.sh` - local build script
+
+Users currently must clone the repo and run `./images/build.sh` before using templates.
+
+## Design Decisions
+
+### Registry
+
+**Decision**: GitHub Container Registry (ghcr.io)
+
+- Free for public repos
+- Native GitHub Actions integration
+- No separate account needed
+
+Image names:
+- `ghcr.io/mattolson/agent-sandbox-base`
+- `ghcr.io/mattolson/agent-sandbox-claude`
+
+### Build Triggers
+
+**Decision**: Build on push to main (with path filter) AND on release tags
+
+- Push to main: builds with `latest` tag and `sha-<commit>` tag
+  - Only when `images/**` or workflow file changes
+  - Docs-only changes don't trigger builds
+- Release tag (v*): builds with version tag (e.g., `v1.0.0`)
+  - Always builds regardless of paths
+
+This gives users a choice:
+- `latest` for always-current (less stable)
+- `v1.0.0` for pinned version (more stable)
+- `@sha256:...` for exact reproducibility
+
+Always build both images together when triggered (base + claude) to avoid missing cascading changes.
+
+### Digest Pinning
+
+**Decision**: Template uses digest pinning by default
+
+```dockerfile
+ARG BASE_IMAGE=ghcr.io/mattolson/agent-sandbox-claude@sha256:abc123...
+FROM ${BASE_IMAGE}
+```
+
+Users can override with `--build-arg BASE_IMAGE=...` for local dev or different versions.
+
+### Multi-arch Support
+
+**Decision**: Defer to later
+
+Start with linux/amd64 only. Add linux/arm64 when needed (Apple Silicon runs amd64 via Rosetta in Docker).
+
+## Tasks
+
+### m2.1-github-actions
+
+Set up GitHub Actions workflow for building images.
+
+- Create `.github/workflows/build-images.yml`
+- Build on push to main (latest + sha tag)
+- Build on version tags (version tag)
+- Push to ghcr.io
+- Output image digests
+
+### m2.2-update-template
+
+Update template to use published images.
+
+- Change Dockerfile FROM to use ghcr.io with digest
+- Update README with digest update instructions
+- Keep local build option via build-arg
+
+### m2.3-docs
+
+Document image versioning and updates.
+
+- How to update to latest digest
+- Version policy (when we bump major/minor/patch)
+- How to use local builds for development
+
+## Definition of Done
+
+- [ ] GitHub Actions builds and pushes images on merge to main
+- [ ] GitHub Actions builds and pushes images on version tags
+- [ ] Template references ghcr.io images with digest
+- [ ] Template README documents how to update digest
+- [ ] Images are publicly pullable without auth
+
+## Open Questions
+
+1. Should we automate digest updates (dependabot, renovate)? Defer to M3 CLI?
+2. Do we need a separate workflow for PRs (build but don't push)?
+
+## Notes
+
+- GHCR auth uses `GITHUB_TOKEN` which is automatic in Actions
+- Public packages are readable without auth after first push
+- First push requires manual package visibility toggle to public


### PR DESCRIPTION
- Add .github/workflows/build-images.yml
- Builds on push to main (with path filter) and releases
- Pushes to ghcr.io with latest, sha, and version tags
- Outputs digests in job summary

- Update template to use ghcr.io/mattolson/agent-sandbox-claude:latest
- No local build required
- Document digest pinning for reproducibility
- Keep local build option via build-arg override

- Update READMEs to reflect GHCR usage