### PR TITLE
Add multi-arch support (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -55,6 +58,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./images/base
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -77,6 +81,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -104,6 +111,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./images/agents/claude
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -122,6 +130,8 @@ jobs:
       - name: Summary
         run: |
           echo "## Image Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Image | Digest |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY

--- a/docs/plan/milestones/m2-images/milestone.md
+++ b/docs/plan/milestones/m2-images/milestone.md
@@ -61,9 +61,12 @@ Users can override with `--build-arg BASE_IMAGE=...` for local dev or different 
 
 ### Multi-arch Support
 
-**Decision**: Defer to later
+**Decision**: Build for both amd64 and arm64
 
-Start with linux/amd64 only. Add linux/arm64 when needed (Apple Silicon runs amd64 via Rosetta in Docker).
+- Use QEMU emulation in GitHub Actions for cross-platform builds
+- Publish manifest list that includes both architectures
+- Docker automatically pulls the correct architecture for the host
+- Native arm64 for Apple Silicon (no Rosetta emulation needed)
 
 ## Tasks
 


### PR DESCRIPTION
## Summary

- Add multi-arch image builds (linux/amd64 + linux/arm64)
- Native Apple Silicon support without Rosetta emulation

## Changes

- Add QEMU setup step for cross-platform builds
- Add platforms: linux/amd64,linux/arm64 to both image builds
- Update job summary to show supported platforms

## How it works

Docker buildx with QEMU builds both architectures and pushes a manifest list. When users pull the image, Docker automatically selects the correct architecture for their host.

Fixes #9 