### PR TITLE
Add shell customization support (m2.5)

### DIFF
--- a/devcontainer/templates/minimal/claude/.devcontainer/devcontainer.json
+++ b/devcontainer/templates/minimal/claude/.devcontainer/devcontainer.json
@@ -23,6 +23,10 @@
     // Inject host Claude config (optional - comment out if not needed)
     "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/dev/.claude/CLAUDE.md,type=bind,readonly",
     "source=${localEnv:HOME}/.claude/settings.json,target=/home/dev/.claude/settings.json,type=bind,readonly"
+    // Shell customizations (optional - uncomment to enable)
+    // "source=${localEnv:HOME}/.config/agent-sandbox/shell.d,target=/home/dev/.config/agent-sandbox/shell.d,type=bind,readonly",
+    // Dotfiles directory (optional - uncomment to enable, use with shell.d script to symlink)
+    // "source=${localEnv:HOME}/.dotfiles,target=/home/dev/.dotfiles,type=bind,readonly"
   ],
   "containerEnv": {
     "TZ": "${localEnv:TZ:America/Los_Angeles}",

--- a/devcontainer/templates/minimal/claude/docker-compose.yml
+++ b/devcontainer/templates/minimal/claude/docker-compose.yml
@@ -31,6 +31,10 @@ services:
       - ${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro
       # To customize network policy, uncomment and create the file:
       # - ${HOME}/.config/agent-sandbox/policy.yaml:/etc/agent-sandbox/policy.yaml:ro
+      # Shell customizations (optional - uncomment to enable)
+      # - ${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro
+      # Dotfiles directory (optional - use with shell.d script to symlink)
+      # - ${HOME}/.dotfiles:/home/dev/.dotfiles:ro
     working_dir: /workspace
     stdin_open: true
     tty: true

--- a/docs/plan/milestones/m2-images/milestone.md
+++ b/docs/plan/milestones/m2-images/milestone.md
@@ -98,11 +98,12 @@ Document image versioning and updates.
 
 ## Definition of Done
 
-- [ ] GitHub Actions builds and pushes images on merge to main
-- [ ] GitHub Actions builds and pushes images on version tags
-- [ ] Template references ghcr.io images with digest
-- [ ] Template README documents how to update digest
-- [ ] Images are publicly pullable without auth
+- [x] GitHub Actions builds and pushes images on merge to main
+- [x] GitHub Actions builds and pushes images on version tags
+- [x] Template references ghcr.io images with digest
+- [x] Template README documents how to update digest
+- [x] Images are publicly pullable without auth
+- [x] Multi-arch support (amd64 + arm64)
 
 ## Open Questions
 

--- a/docs/plan/milestones/m2.5-shell-customization/milestone.md
+++ b/docs/plan/milestones/m2.5-shell-customization/milestone.md
@@ -1,0 +1,169 @@
+# m2.5-shell-customization
+
+Allow users to customize their shell environment without modifying the base image.
+
+## Goals
+
+- Extract built-in aliases from Dockerfile to a sourceable file
+- Add hook directory for user shell customizations
+- Support mounting dotfiles directory for complex setups
+- Document customization patterns
+
+## Current State
+
+Built-in aliases are hardcoded in `images/agents/claude/Dockerfile`:
+
+```dockerfile
+RUN echo "alias yolo-claude='cd /workspace && claude --dangerously-skip-permissions'" >> ~/.zshrc && \
+  echo "alias yc='yolo-claude'" >> ~/.zshrc
+```
+
+Problems:
+- Not all users want these aliases
+- No clean way to add user customizations
+- Users who want their host shell setup can't easily bring it in
+
+## Design
+
+### Shell initialization order
+
+1. Base zsh config (oh-my-zsh, theme, etc.)
+2. Built-in agent aliases (`/etc/agent-sandbox/aliases.sh`) - optional, sourced by default
+3. User customizations (`~/.config/agent-sandbox/shell.d/*.sh`) - if mounted
+
+### Built-in aliases
+
+Move from hardcoded in Dockerfile to a separate file:
+
+```
+/etc/agent-sandbox/aliases.sh
+```
+
+Contents:
+```bash
+# Agent Sandbox convenience aliases
+alias yolo-claude='cd /workspace && claude --dangerously-skip-permissions'
+alias yc='yolo-claude'
+```
+
+Sourced at end of `.zshrc`:
+```bash
+# Source agent-sandbox aliases
+[ -f /etc/agent-sandbox/aliases.sh ] && source /etc/agent-sandbox/aliases.sh
+```
+
+### User customization hook
+
+Add to `.zshrc`:
+```bash
+# Source user customizations
+if [ -d ~/.config/agent-sandbox/shell.d ]; then
+  for f in ~/.config/agent-sandbox/shell.d/*.sh; do
+    [ -f "$f" ] && source "$f"
+  done
+fi
+```
+
+User mounts their customizations:
+```yaml
+# docker-compose.yml or devcontainer.json
+volumes:
+  - ${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro
+```
+
+### Dotfiles directory
+
+For users with existing dotfiles repos, mount the whole thing:
+
+```yaml
+volumes:
+  - ${HOME}/.dotfiles:/home/dev/.dotfiles:ro
+```
+
+Then create a script in `shell.d/` that symlinks as needed:
+
+```bash
+# ~/.config/agent-sandbox/shell.d/00-dotfiles.sh
+[ -d ~/.dotfiles ] && {
+  ln -sf ~/.dotfiles/aliases ~/.aliases
+  ln -sf ~/.dotfiles/functions ~/.functions
+  source ~/.aliases
+  source ~/.functions
+}
+```
+
+## Tasks
+
+### m2.5.1 - Extract aliases to file
+
+- Create `/etc/agent-sandbox/aliases.sh` in base image
+- Remove hardcoded aliases from claude Dockerfile
+- Update `.zshrc` to source the aliases file
+
+### m2.5.2 - Add shell.d hook
+
+- Update `.zshrc` to source `~/.config/agent-sandbox/shell.d/*.sh`
+- Create the directory structure in image (empty, for mount target)
+
+### m2.5.3 - Update template
+
+- Add commented-out mounts for shell.d and dotfiles to template
+- Document customization in template README
+
+### m2.5.4 - Documentation
+
+- Add examples for common customizations
+- Document how to skip built-in aliases if unwanted
+- Document dotfiles symlink pattern
+
+## Definition of Done
+
+- [x] Built-in aliases in separate sourceable file
+- [x] shell.d hook directory sourced by zshrc
+- [x] Template shows example mounts (commented out)
+- [x] README documents customization patterns
+- [ ] Tested: custom aliases work
+- [ ] Tested: dotfiles symlink pattern works
+
+## Examples
+
+### Simple: Add a few aliases
+
+```bash
+# ~/.config/agent-sandbox/shell.d/my-aliases.sh
+alias ll='ls -la'
+alias gs='git status'
+```
+
+### Medium: Override built-in aliases
+
+```bash
+# ~/.config/agent-sandbox/shell.d/99-overrides.sh
+# Use different flags for yolo-claude
+alias yolo-claude='cd /workspace && claude --dangerously-skip-permissions --verbose'
+```
+
+### Advanced: Full dotfiles setup
+
+```bash
+# ~/.config/agent-sandbox/shell.d/00-dotfiles.sh
+if [ -d ~/.dotfiles ]; then
+  # Symlink specific files
+  ln -sf ~/.dotfiles/zsh/aliases.zsh ~/.aliases
+  ln -sf ~/.dotfiles/zsh/functions.zsh ~/.functions
+  ln -sf ~/.dotfiles/git/gitconfig ~/.gitconfig
+
+  # Source shell files
+  source ~/.aliases
+  source ~/.functions
+fi
+```
+
+### Skip built-in aliases entirely
+
+```bash
+# ~/.config/agent-sandbox/shell.d/00-no-builtins.sh
+# Unset the built-in aliases if you don't want them
+unalias yolo-claude 2>/dev/null
+unalias yc 2>/dev/null
+```

--- a/images/agents/claude/Dockerfile
+++ b/images/agents/claude/Dockerfile
@@ -1,13 +1,15 @@
 # Claude Code agent image
-# Extends base with Claude Code CLI and aliases
+# Extends base with Claude Code CLI and convenience aliases
 
 ARG BASE_IMAGE=agent-sandbox-base:local
 FROM ${BASE_IMAGE}
 
 # Override base policy with Claude Code endpoints
+# Copy aliases file (sourced by base image's .zshrc)
 USER root
 COPY policy.yaml /etc/agent-sandbox/policy.yaml
-RUN chmod 644 /etc/agent-sandbox/policy.yaml
+COPY aliases.sh /etc/agent-sandbox/aliases.sh
+RUN chmod 644 /etc/agent-sandbox/policy.yaml /etc/agent-sandbox/aliases.sh
 
 # Create claude config directory
 RUN mkdir -p /home/dev/.claude && chown -R dev:dev /home/dev/.claude
@@ -17,7 +19,5 @@ USER dev
 ARG CLAUDE_CODE_VERSION=latest
 RUN curl -fsSL https://claude.ai/install.sh | bash -s $CLAUDE_CODE_VERSION
 
-# Add Claude to PATH and set up aliases
-RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && \
-  echo "alias yolo-claude='cd /workspace && claude --dangerously-skip-permissions'" >> ~/.zshrc && \
-  echo "alias yc='yolo-claude'" >> ~/.zshrc
+# Add Claude to PATH
+RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc

--- a/images/agents/claude/aliases.sh
+++ b/images/agents/claude/aliases.sh
@@ -1,0 +1,6 @@
+# Agent Sandbox - Claude Code aliases
+# These are sourced by ~/.zshrc
+# Override or unset in ~/.config/agent-sandbox/shell.d/ if unwanted
+
+alias yolo-claude='cd /workspace && claude --dangerously-skip-permissions'
+alias yc='yolo-claude'

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -76,19 +76,31 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
   -x
 
-# Copy default network policy and firewall script
+# Copy default network policy, firewall script, and shell init
+# All in /etc/agent-sandbox are root-owned to prevent agent tampering
 COPY policy.yaml /etc/agent-sandbox/policy.yaml
+COPY shell-init.sh /etc/agent-sandbox/shell-init.sh
 COPY init-firewall.sh /usr/local/bin/
+COPY entrypoint.sh /usr/local/bin/
 USER root
-RUN chmod 644 /etc/agent-sandbox/policy.yaml && \
-  chmod +x /usr/local/bin/init-firewall.sh && \
+RUN chmod 644 /etc/agent-sandbox/policy.yaml /etc/agent-sandbox/shell-init.sh && \
+  chown root:root /etc/agent-sandbox/policy.yaml /etc/agent-sandbox/shell-init.sh && \
+  chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh && \
   echo "${USERNAME} ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/firewall && \
   chmod 0440 /etc/sudoers.d/firewall
 
-# Copy and set up entrypoint
-COPY entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/entrypoint.sh
+# Create shell.d directory (root-owned to prevent agent from injecting malicious scripts)
+# Users mount their customizations here; the mount overlays this empty directory
+RUN mkdir -p /home/${USERNAME}/.config/agent-sandbox/shell.d && \
+  chown root:root /home/${USERNAME}/.config/agent-sandbox/shell.d && \
+  chmod 755 /home/${USERNAME}/.config/agent-sandbox/shell.d
+
 USER ${USERNAME}
+
+# Add shell initialization hook to zshrc
+RUN echo '' >> ~/.zshrc && \
+  echo '# Agent Sandbox shell initialization' >> ~/.zshrc && \
+  echo 'source /etc/agent-sandbox/shell-init.sh' >> ~/.zshrc
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["zsh"]

--- a/images/base/shell-init.sh
+++ b/images/base/shell-init.sh
@@ -1,0 +1,13 @@
+# Agent Sandbox shell initialization
+# Sourced at the end of .zshrc
+
+# Source agent-specific aliases if present
+[ -f /etc/agent-sandbox/aliases.sh ] && source /etc/agent-sandbox/aliases.sh
+
+# Source user customizations from shell.d
+# Mount your scripts to ~/.config/agent-sandbox/shell.d/
+if [ -d ~/.config/agent-sandbox/shell.d ]; then
+  for f in ~/.config/agent-sandbox/shell.d/*.sh(N); do
+    [ -f "$f" ] && source "$f"
+  done
+fi


### PR DESCRIPTION
- Extract built-in aliases to /etc/agent-sandbox/aliases.sh
- Add shell-init.sh for shell.d hook (sourced from .zshrc)
- Update template with commented-out mounts for shell.d and dotfiles
- Document customization patterns in README

Users can now:
- Add aliases/functions via ~/.config/agent-sandbox/shell.d/*.sh
- Mount dotfiles and symlink via shell.d script
- Override or remove built-in aliases

Security:
- /etc/agent-sandbox/* files are root-owned (prevents agent tampering)
- ~/.config/agent-sandbox/shell.d is root-owned (prevents agent injection)
- User mounts overlay the directory with their read-only content
