### PR TITLE
Wait for proxy during firewall initialization

### DIFF
--- a/images/base/entrypoint.sh
+++ b/images/base/entrypoint.sh
@@ -6,7 +6,6 @@ set -e
 if iptables -S OUTPUT 2>/dev/null | grep -q "^-P OUTPUT DROP"; then
   echo "Firewall already initialized."
 else
-  echo "Initializing firewall..."
   if ! sudo /usr/local/bin/init-firewall.sh; then
     echo ""
     echo "=========================================="


### PR DESCRIPTION
## Summary

- Replace unreliable gateway ping test with a retry loop that waits for the proxy to become reachable
- Handle startup race condition where agent container starts before proxy is ready
- Move negative test to after positive test to ensure that proxy has already started up

## Context

The previous verification tested if the gateway IP responded to ping, but this was unreliable across Docker runtimes and didn't actually verify the proxy was functional. The new approach directly tests proxy reachability on port 8080 with a 30-second retry window, which handles the common case where the agent container starts before the proxy sidecar is ready to accept connections.