### PR TITLE
Add JetBrains IDE support and document limitations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,17 @@
         "remote.autoForwardPortsSource": "output",
         "security.promptForRemoteFileProtocolHandling": true,
         "terminal.integrated.defaultProfile.linux": "zsh"
+      },
+      "extensions": [
+        "anthropic.claude-code"
+      ]
+    },
+    "jetbrains": {
+      "settings": {
+        "com.intellij:app:HttpConfigurable.use_proxy_pac": true
       }
     }
   },
-  "remoteUser": "dev"
+  "remoteUser": "dev",
+  "overrideCommand": false
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   proxy:
-    image: ghcr.io/mattolson/agent-sandbox-proxy:latest
+    image: agent-sandbox-proxy:local
     environment:
       - PROXY_MODE=enforce
     volumes:
@@ -22,7 +22,7 @@ services:
       retries: 3
 
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-claude:latest
+    image: agent-sandbox-claude:local
     depends_on:
       proxy:
         condition: service_healthy

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/settings.local.json
+.idea

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -85,4 +85,4 @@ RUN mkdir -p /home/${USERNAME}/.config && \
 USER ${USERNAME}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["zsh"]
+CMD [ "sleep", "infinity" ]


### PR DESCRIPTION
JetBrains devcontainer support:
- Add overrideCommand: false to devcontainer.json to prevent IDE from bypassing entrypoint (fixes firewall initialization)
- Change base image CMD to sleep infinity so container stays alive without IDE intervention
- Add JetBrains proxy settings to devcontainer.json

VS Code improvements:
- Auto-install Claude Code extension via devcontainer.json

Documentation:
- Add JetBrains to supported IDEs in runtime modes table
- Add "Claude Code: Terminal vs IDE extension" section explaining the two ways to run Claude in the sandbox
- Add "Known issues" section documenting JetBrains plugin limitation (runs on host, cannot communicate with Claude in container) and VS Code extension retry behavior
- Update security section to reference both VS Code and JetBrains

Development:
- Switch devcontainer compose to use local images for testing
- Add .idea to gitignore