### PR TITLE
Add JetBrains and VS Code extension support to Claude template

### DIFF
--- a/templates/claude/.devcontainer/devcontainer.json
+++ b/templates/claude/.devcontainer/devcontainer.json
@@ -11,8 +11,17 @@
         "remote.autoForwardPortsSource": "output",
         "security.promptForRemoteFileProtocolHandling": true,
         "terminal.integrated.defaultProfile.linux": "zsh"
+      },
+      "extensions": [
+        "anthropic.claude-code"
+      ]
+    },
+    "jetbrains": {
+      "settings": {
+        "com.intellij:app:HttpConfigurable.use_proxy_pac": true
       }
     }
   },
-  "remoteUser": "dev"
+  "remoteUser": "dev",
+  "overrideCommand": false
 }


### PR DESCRIPTION
Did these earlier in the devcontainer for the project, now folding these into the claude template.

- Add overrideCommand: false to prevent IDEs from bypassing entrypoint
- Add Claude Code extension to auto-install in VS Code
- Add JetBrains proxy settings