### PR TITLE
Refactor documentation for multi-agent architecture

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,14 @@ services:
     volumes:
       - proxy-state:/home/mitmproxy/.mitmproxy
       - proxy-ca:/ca-export
-      - ${HOME}/.config/agent-sandbox/policies/claude.yaml:/etc/mitmproxy/policy.yaml:ro
+      - ${HOME}/.config/agent-sandbox/policies/all-agents.yaml:/etc/mitmproxy/policy.yaml:ro
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "8080"]
       interval: 5s
       timeout: 3s
       retries: 3
 
-  agent:
+  claude:
     image: agent-sandbox-claude:local
     depends_on:
       proxy:
@@ -69,8 +69,42 @@ services:
       # Disable HTTP/2 in Go clients (gh CLI) to avoid header validation issues through proxy
       - GODEBUG=http2client=0
 
+  copilot:
+    image: agent-sandbox-copilot:local
+    depends_on:
+      proxy:
+        condition: service_healthy
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      # Your project workspace
+      - .:/workspace
+      # Persist Copilot credentials
+      - copilot-state:/home/dev/.copilot
+      # Persist shell history
+      - copilot-history:/commandhistory
+      # Proxy CA certificate (public cert only, no private key)
+      - proxy-ca:/etc/mitmproxy:ro
+      # Shell customizations (optional - uncomment to enable)
+      # - ${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro
+      # Dotfiles directory (optional - use with shell.d script to symlink)
+      # - ${HOME}/.dotfiles:/home/dev/.dotfiles:ro
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    environment:
+      - TZ=${TZ:-America/Los_Angeles}
+      - HTTP_PROXY=http://proxy:8080
+      - HTTPS_PROXY=http://proxy:8080
+      - NO_PROXY=localhost,127.0.0.1,proxy
+      # Disable HTTP/2 in Go clients (gh CLI) to avoid header validation issues through proxy
+      - GODEBUG=http2client=0
+
 volumes:
   claude-state:
   claude-history:
+  copilot-state:
+  copilot-history:
   proxy-state:
   proxy-ca:

--- a/docs/policy/examples/all-agents.yaml
+++ b/docs/policy/examples/all-agents.yaml
@@ -1,0 +1,10 @@
+# All agents policy (CLI mode)
+#
+# Union of Claude Code and GitHub Copilot policies.
+# Use this when running the development docker-compose.yml which includes both agents.
+# Copy to: ~/.config/agent-sandbox/policies/all-agents.yaml
+
+services:
+  - github
+  - claude
+  - copilot

--- a/docs/policy/examples/claude-devcontainer.yaml
+++ b/docs/policy/examples/claude-devcontainer.yaml
@@ -1,4 +1,4 @@
-# Claude Code policy (VS Code devcontainer mode)
+# Claude Code policy (devcontainer mode)
 #
 # Includes VS Code infrastructure domains in addition to Claude Code requirements.
 # Copy to: ~/.config/agent-sandbox/policies/claude-devcontainer.yaml

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Detailed project plan can be found in [docs/plan/project.md](./docs/plan/project.md) and related files.
+Detailed project plan can be found in [plan/project.md](./plan/project.md) and related files.
 
 ## m1: Devcontainer template (done)
 
@@ -31,10 +31,11 @@ Detailed project plan can be found in [docs/plan/project.md](./docs/plan/project
 
 ## m4: Multi-agent support (in progress)
 
+- [x] Claude Code support (`templates/claude/`)
 - [x] GitHub Copilot CLI support (`templates/copilot/`)
+- [ ] Gemini support
 - [ ] Codex support
 - [ ] OpenCode support
-- [ ] Agent-specific images and configuration
 
 ## m5: CLI
 

--- a/templates/copilot/README.md
+++ b/templates/copilot/README.md
@@ -16,8 +16,7 @@ The proxy requires policy files on the host. Copy the examples:
 
 ```bash
 mkdir -p ~/.config/agent-sandbox/policies
-cp agent-sandbox/docs/policy/examples/copilot.yaml ~/.config/agent-sandbox/policies/copilot.yaml
-cp agent-sandbox/docs/policy/examples/copilot-devcontainer.yaml ~/.config/agent-sandbox/policies/copilot-devcontainer.yaml
+cp agent-sandbox/docs/policy/examples/copilot* ~/.config/agent-sandbox/policies/
 ```
 
 The compose files mount the appropriate policy:
@@ -49,8 +48,6 @@ cd /path/to/your/project
 docker compose up -d
 docker compose exec agent zsh
 ```
-
-Note: CLI mode requires the policy file at `~/.config/agent-sandbox/policies/copilot.yaml`.
 
 ### 4. Authenticate Copilot (first run only)
 


### PR DESCRIPTION
- Simplify main README to be agent-agnostic, delegate to template READMEs
- Add copilot service to development compose file for side-by-side testing
- Create all-agents.yaml policy combining claude and copilot domains
- Move ROADMAP.md to docs/roadmap.md
- Expand templates/claude/README.md with detailed setup instructions
- Add copilot build target to images/build.sh