### PR TITLE
feat: Add Pi Coding Agent support with multi-provider capability

### DIFF
--- a/.github/workflows/check-pi-version.yml
+++ b/.github/workflows/check-pi-version.yml
@@ -1,0 +1,72 @@
+name: Check Pi Coding Agent Version
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 8am UTC (offset from Claude and Copilot checks)
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/agent-sandbox-pi
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      actions: write  # Needed to trigger workflows
+
+    steps:
+      - name: Get latest Pi Coding Agent version from npm
+        id: npm
+        run: |
+          VERSION=$(npm view @mariozechner/pi-coding-agent@latest version 2>/dev/null || echo "")
+          if [ -z "$VERSION" ]; then
+            echo "Failed to fetch version from npm"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Latest npm version: $VERSION"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if version tag exists in registry
+        id: check
+        run: |
+          TAG="pi-${{ steps.npm.outputs.version }}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+
+          # Use docker manifest inspect to check if tag exists (no pull required)
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG does not exist"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+
+      - name: Trigger image rebuild
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering build-images workflow for Pi Coding Agent ${{ steps.npm.outputs.version }}..."
+          gh workflow run build-images.yml --repo ${{ github.repository }}
+
+      - name: Summary
+        run: |
+          echo "## Pi Coding Agent Version Check" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| npm latest | ${{ steps.npm.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag exists | ${{ steps.check.outputs.exists }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Rebuild triggered | ${{ steps.check.outputs.exists == 'false' }} |" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Target platform: [Colima](https://github.com/abiosoft/colima) + [Docker Engine](
 
 ## What it does
 
-Creates a sandboxed environment for AI coding agents (Claude Code, GitHub Copilot CLI) that:
+Creates a sandboxed environment for AI coding agents (Claude Code, GitHub Copilot CLI, Pi) that:
 
 - Routes all HTTP/HTTPS traffic through an enforcing proxy sidecar
 - Blocks requests to domains not on the allowlist (403 with domain name in response)
@@ -25,6 +25,7 @@ Creates a sandboxed environment for AI coding agents (Claude Code, GitHub Copilo
 |-------|----------|--------|
 | [Claude Code](https://claude.ai/code) | `templates/claude/` | ✅ Stable |
 | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | `templates/copilot/` | 🧪 Preview |
+| [Pi Coding Agent](https://pi.dev/) | `templates/pi/` | 🧪 Preview |
 
 ## Runtime modes
 

--- a/images/agents/pi/Dockerfile
+++ b/images/agents/pi/Dockerfile
@@ -1,0 +1,38 @@
+# Pi Coding Agent image
+# Extends base with Pi CLI installed via npm
+
+ARG BASE_IMAGE=agent-sandbox-base:local
+FROM ${BASE_IMAGE}
+
+# Optional extra packages
+ARG PI_EXTRA_PACKAGES=""
+USER root
+RUN if [ -n "$PI_EXTRA_PACKAGES" ]; then \
+      printf '%s' "$PI_EXTRA_PACKAGES" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9.+ :-]*$' \
+        || { echo "ERROR: PI_EXTRA_PACKAGES contains invalid characters: $PI_EXTRA_PACKAGES" >&2; exit 1; }; \
+      apt-get update && apt-get install -y --no-install-recommends $PI_EXTRA_PACKAGES \
+      && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Install Node.js (required for npm) via NodeSource apt repo with GPG verification
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o /tmp/nodesource.key && \
+    gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg /tmp/nodesource.key && \
+    rm /tmp/nodesource.key && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && apt-get install -y nodejs ripgrep fd-find && \
+    ln -s /usr/bin/fdfind /usr/local/bin/fd && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create pi config directory
+RUN mkdir -p /home/dev/.pi && chown -R dev:dev /home/dev/.pi
+
+# Install Pi CLI via npm - must be root for global install
+ARG PI_VERSION=latest
+RUN npm install -g @mariozechner/pi-coding-agent@${PI_VERSION}
+
+USER dev
+
+LABEL org.opencontainers.image.description="Agent Sandbox with Pi Coding Agent"
+LABEL com.mattolson.agentsandbox.pi-version="${PI_VERSION}"

--- a/images/proxy/addons/enforcer.py
+++ b/images/proxy/addons/enforcer.py
@@ -58,6 +58,16 @@ SERVICE_DOMAINS = {
        "plugins.jetbrains.com",
        "downloads.marketplace.jetbrains.com",
     ],
+    "codex": [
+        "api.openai.com",
+        "*.openai.com",
+        "chatgpt.com",
+        "*.chatgpt.com",
+    ],
+    "gemini": [
+        "generativelanguage.googleapis.com",
+        "*.googleapis.com",
+    ],
 }
 
 

--- a/templates/pi/.devcontainer/devcontainer.json
+++ b/templates/pi/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Pi Coding Agent Sandbox",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "agent",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "remote.autoForwardPorts": false,
+        "remote.forwardOnOpen": false,
+        "remote.autoForwardPortsSource": "output",
+        "security.promptForRemoteFileProtocolHandling": true,
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    },
+    "jetbrains": {
+      "settings": {
+        "com.intellij:app:HttpConfigurable.use_http_proxy": true,
+        "com.intellij:app:HttpConfigurable.proxy_host": "proxy",
+        "com.intellij:app:HttpConfigurable.proxy_port": "8080",
+        "com.intellij:app:HttpConfigurable.proxy_exceptions": "localhost,127.0.0.1,proxy"
+      }
+    }
+  },
+  "remoteUser": "dev",
+  "overrideCommand": false
+}

--- a/templates/pi/.devcontainer/docker-compose.yml
+++ b/templates/pi/.devcontainer/docker-compose.yml
@@ -1,0 +1,75 @@
+# Pi Coding Agent Sandbox
+#
+# Works with both devcontainer (VS Code, JetBrains) and CLI usage.
+# A .env file at the project root sets COMPOSE_FILE so that
+# `docker compose` commands work from the project directory.
+#
+# CLI usage:
+#   docker compose up -d
+#   docker compose exec agent zsh
+#   pi
+#   docker compose down
+#
+# For reproducibility, pin images to a specific digest:
+#   image: ghcr.io/mattolson/agent-sandbox-pi@sha256:<digest>
+#   image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:<digest>
+
+services:
+  proxy:
+    image: ghcr.io/mattolson/agent-sandbox-proxy:latest
+    environment:
+      - PROXY_MODE=enforce
+    volumes:
+      - proxy-state:/home/mitmproxy/.mitmproxy
+      - proxy-ca:/ca-export
+      - ./policy.yaml:/etc/mitmproxy/policy.yaml:ro
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "8080"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  agent:
+    image: ghcr.io/mattolson/agent-sandbox-pi:latest
+    depends_on:
+      proxy:
+        condition: service_healthy
+    # Required for iptables firewall setup. The agent runs as non-root and
+    # sudoers only permits specific scripts, so it cannot modify iptables directly.
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      # Project workspace
+      - ../:/workspace
+      # Prevent agent from modifying compose, policy, or devcontainer config
+      - .:/workspace/.devcontainer:ro
+      # Persist Pi credentials and state
+      - pi-state:/home/dev/.pi
+      # Persist shell history
+      - pi-history:/commandhistory
+      # Proxy CA certificate (public cert only, no private key)
+      - proxy-ca:/etc/mitmproxy:ro
+      # Dotfiles (optional - auto-linked into $HOME at startup)
+      # - ${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro
+      #
+      # Shell customizations (optional - scripts sourced at shell startup)
+      # - ${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    environment:
+      - TZ=${TZ:-America/Los_Angeles}
+      - HTTP_PROXY=http://proxy:8080
+      - HTTPS_PROXY=http://proxy:8080
+      - NO_PROXY=localhost,127.0.0.1,proxy
+      # Node.js: Trust mitmproxy CA certificate for HTTPS interception
+      - NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt
+      # Disable HTTP/2 in Go clients (gh CLI) to avoid header validation issues through proxy
+      - GODEBUG=http2client=0
+
+volumes:
+  pi-state:
+  pi-history:
+  proxy-state:
+  proxy-ca:

--- a/templates/pi/.devcontainer/policy.yaml
+++ b/templates/pi/.devcontainer/policy.yaml
@@ -1,0 +1,23 @@
+# Pi Coding Agent sandbox network policy
+#
+# Pi supports multiple AI providers. Choose which backend(s) to enable
+# by adding the appropriate services below:
+#
+# Available AI provider services:
+#   - claude    # Anthropic Claude API
+#   - codex     # OpenAI API (GPT models, ChatGPT)
+#   - copilot   # GitHub Copilot
+#   - gemini    # Google Gemini API
+#
+# See docs/policy/schema.md for the full format reference.
+
+services:
+  - github
+  - codex      # Default: OpenAI/Codex backend (change as needed)
+  - vscode
+  - jetbrains
+
+# Additional one-off domains can be added here as needed
+# (e.g., for Azure OpenAI or other providers)
+# domains:
+#   - myorg.openai.azure.com

--- a/templates/pi/.env
+++ b/templates/pi/.env
@@ -1,0 +1,1 @@
+COMPOSE_FILE=.devcontainer/docker-compose.yml

--- a/templates/pi/README.md
+++ b/templates/pi/README.md
@@ -1,0 +1,327 @@
+# Pi Coding Agent Sandbox Template
+
+Run Pi Coding Agent in a network-locked container. All outbound traffic is routed through an enforcing proxy that blocks requests to domains not on the allowlist.
+
+## Quick Start
+
+### 1. Clone the agent-sandbox repo
+
+```bash
+git clone https://github.com/mattolson/agent-sandbox.git
+```
+
+### 2. Copy template to your project
+
+```bash
+cp -r agent-sandbox/templates/pi/.devcontainer /path/to/your/project/
+cp agent-sandbox/templates/pi/.env /path/to/your/project/
+```
+
+The `.devcontainer/` directory contains the compose file, devcontainer config, and network policy. The `.env` file tells Docker Compose where to find the compose file.
+
+### 3. Start the sandbox
+
+**Devcontainer (VS Code / JetBrains):**
+
+VS Code:
+1. Install the Dev Containers extension
+2. Command Palette > "Dev Containers: Reopen in Container"
+
+JetBrains (IntelliJ, PyCharm, WebStorm, etc.):
+1. Open your project
+2. From the Remote Development menu, select "Dev Containers"
+3. Select the devcontainer configuration
+
+**CLI (terminal):**
+
+```bash
+cd /path/to/your/project
+docker compose up -d
+docker compose exec agent zsh
+```
+
+### 4. Configure AI provider (first run only)
+
+Pi supports multiple AI providers (Anthropic Claude, OpenAI, Google Gemini, etc.). You need to authenticate with at least one provider before using Pi.
+
+Inside the container, run Pi and use the `/login` command:
+
+```bash
+pi
+# Then in the Pi interface:
+/login
+```
+
+Pi will guide you through:
+1. Selecting your preferred AI provider
+2. Authenticating (e.g., providing an API key or OAuth flow)
+3. Optionally setting a default model
+
+**Environment variables:**
+
+You can also configure providers via environment variables. Add to the `agent` service in `docker-compose.yml`:
+
+```yaml
+environment:
+  - ANTHROPIC_API_KEY=sk-ant-...
+  - OPENAI_API_KEY=sk-...
+```
+
+**Network policy:**
+
+Make sure your network policy (`.devcontainer/policy.yaml`) includes the service for your chosen provider:
+
+- For Anthropic Claude: Add `claude` to the services list
+- For OpenAI/ChatGPT: Add `codex` to the services list
+- For Google Gemini: Add `gemini` to the services list
+- For multiple providers: Add all that you need
+
+See the Network Policy section below for details.
+
+### 5. Use Pi
+
+Inside the container:
+
+```bash
+pi
+```
+
+Pi will start in interactive mode. You can then issue coding tasks, ask questions, or use Pi's workflow commands.
+
+Afterward, for CLI mode, stop the container:
+
+```bash
+docker compose down
+```
+
+## How It Works
+
+Two containers run as a Docker Compose stack:
+
+1. **proxy** (mitmproxy) - Enforces a domain allowlist. Blocks HTTP and HTTPS requests to non-allowed domains with 403. Logs all traffic as JSON to stdout.
+2. **agent** (Pi CLI) - Your development environment. All HTTP/HTTPS traffic is routed through the proxy via `HTTP_PROXY`/`HTTPS_PROXY` env vars. An iptables firewall blocks any direct outbound connections, so traffic cannot bypass the proxy.
+
+The proxy's CA certificate is automatically shared with the agent container and installed into the system trust store at startup.
+
+## Network Policy
+
+### Policy location
+
+The network policy lives in your project at `.devcontainer/policy.yaml`. This file is checked into version control and shared with your team.
+
+The `.devcontainer/` directory is mounted read-only inside the agent container, preventing the agent from modifying the policy, compose file, or devcontainer config. The proxy only reads the policy at startup, so even if the file were changed, it would not take effect until a human restarts the proxy from the host.
+
+### Multi-provider support
+
+Pi supports multiple AI providers. The default template includes the `codex` service (OpenAI), but you can customize this for your needs.
+
+**To use Anthropic Claude:**
+
+```yaml
+services:
+  - github
+  - claude      # Anthropic Claude API
+  - vscode
+  - jetbrains
+```
+
+**To use Google Gemini:**
+
+```yaml
+services:
+  - github
+  - gemini      # Google Gemini API
+  - vscode
+  - jetbrains
+```
+
+**To use multiple providers:**
+
+```yaml
+services:
+  - github
+  - claude      # Anthropic Claude API
+  - codex       # OpenAI API
+  - gemini      # Google Gemini API
+  - vscode
+  - jetbrains
+```
+
+**For Azure OpenAI or custom endpoints:**
+
+```yaml
+services:
+  - github
+  - vscode
+  - jetbrains
+
+domains:
+  - myorg.openai.azure.com
+```
+
+Restart the proxy after changes: `docker compose restart proxy`
+
+### Policy format
+
+```yaml
+services:
+  - github  # Expands to github.com, *.github.com, *.githubusercontent.com
+  - claude  # Expands to Anthropic Claude API domains
+  - codex   # Expands to OpenAI API domains
+  - gemini  # Expands to Google Gemini API domains
+  - vscode  # Expands to VS Code infrastructure domains
+
+domains:
+  - api.example.com        # Exact match
+  - "*.example.com"        # Wildcard suffix match (also matches example.com)
+```
+
+## Verifying the Sandbox
+
+```bash
+# Inside container:
+
+# Should fail with 403 (blocked by proxy)
+curl -s -o /dev/null -w "%{http_code}" https://example.com
+
+# Should succeed (GitHub is allowed)
+curl -s https://api.github.com/zen
+
+# Direct outbound bypassing proxy should also fail (blocked by iptables)
+curl --noproxy '*' --connect-timeout 3 https://example.com
+```
+
+## Dotfiles
+
+Mount your dotfiles directory to have them auto-linked into `$HOME` at container startup:
+
+```yaml
+volumes:
+  - ${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro
+```
+
+The entrypoint recursively walks `~/.dotfiles` and creates symlinks for each file at the corresponding `$HOME` path. Intermediate directories are created as needed.
+
+For example, if your dotfiles contain:
+```
+.dotfiles/
+  .zshrc
+  .gitconfig
+  .config/
+    git/config
+    starship.toml
+```
+
+The container will have:
+- `~/.zshrc` -> `~/.dotfiles/.zshrc`
+- `~/.gitconfig` -> `~/.dotfiles/.gitconfig`
+- `~/.config/git/config` -> `~/.dotfiles/.config/git/config`
+- `~/.config/starship.toml` -> `~/.dotfiles/.config/starship.toml`
+
+Protected paths (`.config/agent-sandbox`) are never overwritten. Shell-init hooks are sourced from the system-level zshrc (`/etc/zsh/zshrc`), which runs before `~/.zshrc`, so your dotfiles can include a custom `.zshrc` without breaking agent-sandbox functionality.
+
+## Shell Customization
+
+Mount scripts into `~/.config/agent-sandbox/shell.d/` to customize your shell environment. Any `*.sh` files are sourced when zsh starts (before `~/.zshrc`).
+
+```bash
+mkdir -p ~/.config/agent-sandbox/shell.d
+
+cat > ~/.config/agent-sandbox/shell.d/my-aliases.sh << 'EOF'
+alias ll='ls -la'
+alias gs='git status'
+EOF
+```
+
+Uncomment the shell.d mount in the compose file.
+
+## Language Stacks
+
+The base image ships installer scripts for common language stacks. Use them in a custom Dockerfile or via the `STACKS` build arg.
+
+### Custom Dockerfile
+
+```dockerfile
+FROM ghcr.io/mattolson/agent-sandbox-pi:latest
+USER root
+RUN /etc/agent-sandbox/stacks/python.sh
+RUN /etc/agent-sandbox/stacks/go.sh 1.23.6
+USER dev
+```
+
+Build and use your custom image:
+```bash
+docker build -t my-pi-sandbox .
+# Update .devcontainer/docker-compose.yml to use image: my-pi-sandbox
+```
+
+### STACKS build arg
+
+If building from source, use the `STACKS` env var. Stacks are installed in the base image, so build with `all` or build base first:
+
+```bash
+STACKS="python,go:1.23.6" ./images/build.sh all
+```
+
+### Available stacks
+
+| Stack | Script | Version arg | Default |
+|-------|--------|-------------|---------|
+| Python | `python.sh` | (ignored, uses apt) | System Python 3 |
+| Node.js | `node.sh` | Major version | 22 |
+| Go | `go.sh` | Full version | 1.23.6 |
+| Rust | `rust.sh` | Toolchain | stable |
+
+Each script handles both amd64 and arm64 architectures.
+
+## Image Versioning
+
+By default, the template pulls `:latest`. For reproducibility, pin to a specific digest:
+
+```yaml
+image: ghcr.io/mattolson/agent-sandbox-pi@sha256:<digest>
+image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:<digest>
+```
+
+To find the current digest:
+
+```bash
+docker pull ghcr.io/mattolson/agent-sandbox-pi:latest
+docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/mattolson/agent-sandbox-pi:latest
+```
+
+To use locally-built images instead:
+
+```bash
+cd agent-sandbox && ./images/build.sh
+# Then update the compose file to use:
+#   image: agent-sandbox-pi:local
+#   image: agent-sandbox-proxy:local
+```
+
+## Troubleshooting
+
+### Proxy health check fails
+
+The agent container waits for the proxy to be healthy before starting. If the proxy fails to start, check its logs:
+
+```bash
+docker compose logs proxy
+```
+
+### Pi cannot connect to AI provider
+
+1. Verify your API key is set correctly (environment variable or Pi's `/login` command)
+2. Check that the appropriate service is enabled in `.devcontainer/policy.yaml`
+3. Restart the proxy: `docker compose restart proxy`
+4. Verify from inside the container:
+   ```bash
+   # For Claude
+   curl https://api.anthropic.com
+
+   # For OpenAI
+   curl https://api.openai.com
+
+   # For Gemini
+   curl https://generativelanguage.googleapis.com
+   ```


### PR DESCRIPTION
Add Pi (pi.dev) as a supported agent with configurable AI provider access:
- New Pi agent image with Node.js, ripgrep, and fd
- Build script support for Pi with PI_VERSION and PI_EXTRA_PACKAGES
- Template with docker-compose, policy, devcontainer config, and docs
- Proxy enforcer services for codex (OpenAI) and gemini (Google) backends
- CI workflow to auto-check npm for Pi updates and trigger rebuilds
- Node.js proxy configuration with CA cert trust via NODE_EXTRA_CA_CERTS

Pi supports multiple AI providers (Claude, OpenAI, Gemini, etc.). Users explicitly choose which backends to enable in their policy.yaml using the new service definitions (claude, codex, gemini), providing fine-grained control over network access.