### PR TITLE
fix: Set passwd shell to /bin/bash

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -34,7 +34,7 @@ RUN if [ -n "$EXTRA_PACKAGES" ]; then \
 
 # Set up non-root user
 ARG USERNAME=dev
-RUN groupadd --system --gid 500 ${USERNAME} && useradd --system --create-home --uid 500 --gid 500 ${USERNAME}
+RUN groupadd --system --gid 500 ${USERNAME} && useradd --system --create-home --uid 500 --gid 500 --shell /bin/bash ${USERNAME}
 
 # Persist shell history (docker volume)
 RUN mkdir /commandhistory \


### PR DESCRIPTION
This is to workaround devcontainers features issue https://github.com/devcontainers/features/issues/1582

The shell used by `exec` stays as zsh:
```
dev@18c422a7f033:/workspace% ps -p $$
    PID TTY          TIME CMD
   1553 pts/3    00:00:00 zsh
```