### PR TITLE
CLI usability improvements

### DIFF
--- a/cli/lib/composefile.bash
+++ b/cli/lib/composefile.bash
@@ -91,9 +91,9 @@ customize_compose_file() {
 	fi
 
 	# Remove blank lines between volume entries/comments.
-	# yq inserts blank lines between foot comments and the next sibling;
-	# this strips any blank line that sits between two indented lines.
-	# Uses D to delete only the blank line, keeping the appended line.
+	# yq inserts blank lines between foot comments and the next sibling.
+	# When a blank line is followed by an indented line, strip the blank line
+	# via substitution to keep the indented line intact.
 	sed '/^$/{ N; /^\n[[:space:]]/{ s/^\n//; }; }' "$compose_file" > "$compose_file.tmp" && mv "$compose_file.tmp" "$compose_file"
 }
 

--- a/cli/lib/select.bash
+++ b/cli/lib/select.bash
@@ -29,17 +29,25 @@ select_option() {
 	local prompt="$1"
 	shift
 	local options=("$@")
-	local PS3="$prompt "
+	local default="${options[0]}"
+	local i
 
-	local choice
-	select choice in "${options[@]}"; do
-		if [[ -n $choice ]]
-		then
-			printf '%s\n' "$choice"
-			break
-		else
-			echo "Invalid selection, try again." >&2
+	for i in "${!options[@]}"; do
+		echo "  $((i+1))) ${options[$i]}" >&2
+	done
+
+	local reply
+	while true; do
+		read -rp "$prompt [$default] " reply >&2
+		if [[ -z $reply ]]; then
+			printf '%s\n' "$default"
+			return
 		fi
+		if [[ $reply =~ ^[0-9]+$ ]] && (( reply >= 1 && reply <= ${#options[@]} )); then
+			printf '%s\n' "${options[$((reply-1))]}"
+			return
+		fi
+		echo "Invalid selection, try again." >&2
 	done
 }
 


### PR DESCRIPTION
## Summary

Small UX fixes for `agentbox init`.

### Changes

- **Project name at top of compose file.** `set_project_name` now places the `name:` key before `services:` instead of appending it at the bottom.

- **Default selections.** `select_option` defaults to the first option when the user presses Enter without typing a number. The default is shown in brackets in the prompt (e.g., `Select agent: [claude]`). Agent defaults to `claude`, mode defaults to `cli`.

- **Comment fix.** Corrected an inaccurate comment on the sed post-processing step in `customize_compose_file`.