### PR TITLE
fix: Mount IDE config dirs as RO by default

### DIFF
--- a/cli/lib/composefile.bash
+++ b/cli/lib/composefile.bash
@@ -51,12 +51,12 @@ customize_compose_file() {
 
 	if [[ $ide == "jetbrains" ]]
 	then
-		: "${AGENTBOX_MOUNT_IDEA_READONLY:=false}"
+		: "${AGENTBOX_MOUNT_IDEA_READONLY:=true}"
 	fi
 
 	if [[ $ide == "vscode" ]]
 	then
-		: "${AGENTBOX_MOUNT_VSCODE_READONLY:=false}"
+		: "${AGENTBOX_MOUNT_VSCODE_READONLY:=true}"
 	fi
 
 	local proxy_image_pinned

--- a/cli/test/composefile/composefile.bats
+++ b/cli/test/composefile/composefile.bats
@@ -233,6 +233,7 @@ EOF
 EOF
 }
 
+# shellcheck disable=SC2016
 @test "customize_compose_file defaults all optional volumes to commented-out entries" {
 	POLICY_FILE="policy.yaml"
 	touch "$BATS_TEST_TMPDIR/$POLICY_FILE"
@@ -257,18 +258,23 @@ EOF
 	# Verify policy volume on proxy
 	yq -e '.services.proxy.volumes[] | select(. == "policy.yaml:/etc/mitmproxy/policy.yaml:ro")' "$COMPOSE_FILE"
 
-	# Only the initial workspace volume should be active
-	run yq '.services.agent.volumes | length' "$COMPOSE_FILE"
-	assert_output "1"
+	# Verify .idea volume
+	yq -e '.services.agent.volumes[] | select(. == "../.idea:/workspace/.idea:ro")' "$COMPOSE_FILE"
 
-	# All optional volumes should appear as foot comments
-	run yq '.services.agent.volumes[-1] | foot_comment' "$COMPOSE_FILE"
-	assert_line --partial '${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro'
-	assert_line --partial '${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro'
-	assert_line --partial 'shell.d:/home/dev/.config/agent-sandbox/shell.d:ro'
-	assert_line --partial 'dotfiles:/home/dev/.dotfiles:ro'
-	assert_line --partial '../.git:/workspace/.git:ro'
-	assert_line --partial '../.idea:/workspace/.idea:ro'
+	# With JetBrains IDE, the .idea mount is active by default, so there should be two active volumes
+	run yq '.services.agent.volumes | length' "$COMPOSE_FILE"
+	assert_output "2"
+
+	# Optional inactive mounts should be present as foot comments on the initial workspace volume entry
+	# Note: sed on line 92 of composefile.bash merges foot comments into the next sibling as head comments
+	# so the yq's foot_comment is empty.
+	run yq -P '.services.agent.volumes' "$COMPOSE_FILE"
+	assert_line '# - ${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro'
+	assert_line '# - ${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro'
+	assert_line '# - ${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro'
+	assert_line '# - ${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro'
+	assert_line '# - ../.git:/workspace/.git:ro'
+	assert_line '# - ../.vscode:/workspace/.vscode:ro'
 
 	# JetBrains capabilities should still be added
 	assert_jetbrains_capabilities "$COMPOSE_FILE"


### PR DESCRIPTION
The setup should be secure by default