### PR TITLE
feat: Restart compose by default

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -66,7 +66,10 @@ Displays the current version of agent-sandbox.
 
 ### `agentbox edit compose`
 
-Opens the Docker Compose file in your editor. If you save changes and containers are running, warns you to restart.
+Opens the Docker Compose file in your editor. If you save changes and containers are running, it will restart containers by default to apply the changes.
+
+Options:
+- `--no-restart` — Do not automatically restart containers after changes. When set (or when `AGENTBOX_NO_RESTART=true`), a warning is shown instead with instructions to run `agentbox up -d` manually.
 
 ### `agentbox edit policy`
 

--- a/cli/libexec/edit/compose
+++ b/cli/libexec/edit/compose
@@ -10,6 +10,22 @@ source "$AGB_LIBDIR/logging.bash"
 
 # Opens the compose file in an editor. Warns if containers need restarting.
 edit() {
+	local no_restart="${AGENTBOX_NO_RESTART:-false}"
+
+	while [[ $# -gt 0 ]]
+	do
+		case $1 in
+		--no-restart)
+			no_restart=true
+			shift
+			;;
+		*)
+			echo "Unknown option: $1" | error
+			return 1
+			;;
+		esac
+	done
+
 	local compose_file
 	compose_file="$(find_compose_file)"
 
@@ -28,8 +44,14 @@ edit() {
 
 		if [[ -n "$running" ]]
 		then
-			echo "Compose file was modified, and you have containers running." | warning
-			echo "To pick up the changes and restart your containers, run: agentbox up -d" | warning
+			if [[ "$no_restart" == "true" ]]
+			then
+				echo "Compose file was modified, and you have containers running." | warning
+				echo "To pick up the changes and restart your containers, run: agentbox up -d" | warning
+			else
+				echo "Compose file was modified. Restarting containers..." | info
+				"$AGB_LIBDIR/run-compose" up -d
+			fi
 		else
 			echo "Compose file was modified." | info
 		fi

--- a/cli/test/edit/compose.bats
+++ b/cli/test/edit/compose.bats
@@ -25,19 +25,20 @@ teardown() {
 	assert_success
 }
 
-@test "edit warns when file modified and containers running" {
+@test "edit restarts containers when file modified and containers running (default)" {
 	unset -f open_editor
 	stub open_editor \
 		"$COMPOSE_FILE : sleep 1 && touch '$COMPOSE_FILE'"
 
 	stub docker \
-		"compose -f $COMPOSE_FILE ps --status running --quiet : echo running"
+		"compose -f $COMPOSE_FILE ps --status running --quiet : echo running" \
+		"compose -f $COMPOSE_FILE up -d : :"
 
 	cd "$BATS_TEST_TMPDIR"
 	run edit
 	assert_success
-	assert_output --partial "Compose file was modified"
-	assert_output --partial "agentbox up -d"
+	assert_output --partial "Compose file was modified. Restarting containers..."
+	refute_output --partial "agentbox up -d"
 }
 
 @test "edit confirms save when file modified and no containers running" {
@@ -64,4 +65,36 @@ teardown() {
 	run edit
 	assert_success
 	assert_output --partial "No changes detected."
+}
+
+@test "edit with --no-restart warns when modified and containers running" {
+	unset -f open_editor
+	stub open_editor \
+		"$COMPOSE_FILE : sleep 1 && touch '$COMPOSE_FILE'"
+
+	stub docker \
+		"compose -f $COMPOSE_FILE ps --status running --quiet : echo running"
+
+	cd "$BATS_TEST_TMPDIR"
+	run edit --no-restart
+	assert_success
+	assert_output --partial "Compose file was modified, and you have containers running."
+	assert_output --partial "agentbox up -d"
+}
+
+@test "edit respects AGENTBOX_NO_RESTART env var when modified and containers running" {
+	unset -f open_editor
+	stub open_editor \
+		"$COMPOSE_FILE : sleep 1 && touch '$COMPOSE_FILE'"
+
+	stub docker \
+		"compose -f $COMPOSE_FILE ps --status running --quiet : echo running"
+
+	export AGENTBOX_NO_RESTART=true
+	cd "$BATS_TEST_TMPDIR"
+	run edit
+	assert_success
+	assert_output --partial "Compose file was modified, and you have containers running."
+	assert_output --partial "agentbox up -d"
+	unset AGENTBOX_NO_RESTART
 }


### PR DESCRIPTION
Adds `--no-restart`/`AGENTBOX_NO_RESTART`

fixes #81 