### PR TITLE
Add ripgrep to base image packages

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   less \
   procps \
+  ripgrep \
   sudo \
   tmux \
   unzip \


### PR DESCRIPTION
## Summary
- Add `ripgrep` (`rg`) to the base image package set in `images/base/Dockerfile`.

## Why
- Agents prefer `rg` for fast file and text search.
- Including it in the base image makes it available consistently across agent images that inherit from base.

## Changes
- Updated apt install list in `images/base/Dockerfile` to include `ripgrep`.

## Testing
- Built images locally and confirmed that rg is installed

## Impact
- Low risk, additive package install only.
- No behavior changes beyond making `rg` available in the container.