### PR TITLE
Remove redundant Claude and Codex env vars

### DIFF
--- a/cli/templates/claude/cli/docker-compose.yml
+++ b/cli/templates/claude/cli/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     tty: true
     environment:
       - TZ=${TZ:-America/Los_Angeles}
-      - CLAUDE_CONFIG_DIR=/home/dev/.claude
       - CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
       - HTTP_PROXY=http://proxy:8080
       - HTTPS_PROXY=http://proxy:8080

--- a/cli/templates/claude/devcontainer/docker-compose.yml
+++ b/cli/templates/claude/devcontainer/docker-compose.yml
@@ -48,7 +48,6 @@ services:
     tty: true
     environment:
       - TZ=${TZ:-America/Los_Angeles}
-      - CLAUDE_CONFIG_DIR=/home/dev/.claude
       - CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
       - HTTP_PROXY=http://proxy:8080
       - HTTPS_PROXY=http://proxy:8080

--- a/cli/templates/codex/cli/docker-compose.yml
+++ b/cli/templates/codex/cli/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     tty: true
     environment:
       - TZ=${TZ:-America/Los_Angeles}
-      - CODEX_HOME=/home/dev/.codex
       - HTTP_PROXY=http://proxy:8080
       - HTTPS_PROXY=http://proxy:8080
       - NO_PROXY=localhost,127.0.0.1,proxy

--- a/cli/templates/codex/devcontainer/docker-compose.yml
+++ b/cli/templates/codex/devcontainer/docker-compose.yml
@@ -48,7 +48,6 @@ services:
     tty: true
     environment:
       - TZ=${TZ:-America/Los_Angeles}
-      - CODEX_HOME=/home/dev/.codex
       - HTTP_PROXY=http://proxy:8080
       - HTTPS_PROXY=http://proxy:8080
       - NO_PROXY=localhost,127.0.0.1,proxy

--- a/cli/test/init/regression.bats
+++ b/cli/test/init/regression.bats
@@ -116,8 +116,9 @@ claude_agent_compose_file_has_expected_content() {
 
 	assert_proxy_service "$compose_file" "ghcr.io/mattolson/agent-sandbox-proxy@sha256:abc123"
 	assert_agent_service_base "$compose_file" "ghcr.io/mattolson/agent-sandbox-claude@sha256:def456"
-
-	yq -e '.services.agent.environment[] | select(. == "CLAUDE_CONFIG_DIR=/home/dev/.claude")' "$compose_file"
+	yq -e '.services.agent.environment[] | select(. == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")' "$compose_file"
+	run yq '.services.agent.environment[] | select(. == "CLAUDE_CONFIG_DIR=/home/dev/.claude")' "$compose_file"
+	assert_output ""
 
 	assert_common_environment_vars "$compose_file"
 	assert_common_volumes "$compose_file"
@@ -152,6 +153,31 @@ copilot_agent_compose_file_has_expected_content() {
 
 	assert_named_volumes "$compose_file" "copilot-state" "copilot-history" "proxy-state" "proxy-ca"
 	assert_customization_volumes "$compose_file"
+	# shellcheck disable=SC2016
+	run yq '.services.agent.volumes[] | select(. == "${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro")' "$compose_file"
+	assert_output ""
+}
+
+codex_agent_compose_file_has_expected_content() {
+	local compose_file=$1
+
+	assert [ -f "$compose_file" ]
+
+	assert_proxy_service "$compose_file" "ghcr.io/mattolson/agent-sandbox-proxy@sha256:abc123"
+	assert_agent_service_base "$compose_file" "ghcr.io/mattolson/agent-sandbox-codex@sha256:jkl012"
+	run yq '.services.agent.environment[] | select(. == "CODEX_HOME=/home/dev/.codex")' "$compose_file"
+	assert_output ""
+
+	assert_common_environment_vars "$compose_file"
+	assert_common_volumes "$compose_file"
+
+	yq -e '.services.agent.volumes[] | select(. == "codex-state:/home/dev/.codex")' "$compose_file"
+
+	yq -e '.services.agent.volumes[] | select(. == "codex-history:/commandhistory")' "$compose_file"
+
+	assert_named_volumes "$compose_file" "codex-state" "codex-history" "proxy-state" "proxy-ca"
+	assert_customization_volumes "$compose_file"
+
 	# shellcheck disable=SC2016
 	run yq '.services.agent.volumes[] | select(. == "${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro")' "$compose_file"
 	assert_output ""
@@ -266,6 +292,61 @@ copilot_agent_compose_file_has_expected_content() {
 	assert_output "project-sandbox-devcontainer"
 
 	copilot_agent_compose_file_has_expected_content "$PROJECT_DIR/.devcontainer/docker-compose.yml"
+
+	assert_devcontainer_volume "$PROJECT_DIR/.devcontainer/docker-compose.yml"
+}
+
+@test "cli creates docker-compose.yml for codex agent with all standard options enabled" {
+	export AGENTBOX_PROXY_IMAGE="ghcr.io/mattolson/agent-sandbox-proxy:latest"
+	export AGENTBOX_AGENT_IMAGE="ghcr.io/mattolson/agent-sandbox-codex:latest"
+	export AGENTBOX_ENABLE_SHELL_CUSTOMIZATIONS="true"
+	export AGENTBOX_ENABLE_DOTFILES="true"
+	export AGENTBOX_MOUNT_GIT_READONLY="true"
+	export AGENTBOX_MOUNT_IDEA_READONLY="true"
+	export AGENTBOX_MOUNT_VSCODE_READONLY="true"
+
+	unset -f pull_and_pin_image
+	stub pull_and_pin_image \
+		"ghcr.io/mattolson/agent-sandbox-proxy:latest : echo 'ghcr.io/mattolson/agent-sandbox-proxy@sha256:abc123'" \
+		"ghcr.io/mattolson/agent-sandbox-codex:latest : echo 'ghcr.io/mattolson/agent-sandbox-codex@sha256:jkl012'"
+
+	run cli \
+		--policy-file "$POLICY_FILE" \
+		--project-path "$PROJECT_DIR" \
+		--agent "codex"
+	assert_success
+
+	run yq '.name' "$PROJECT_DIR/$AGB_PROJECT_DIR/docker-compose.yml"
+	assert_output "project-sandbox"
+
+	codex_agent_compose_file_has_expected_content "$PROJECT_DIR/$AGB_PROJECT_DIR/docker-compose.yml"
+}
+
+@test "devcontainer creates docker-compose.yml for codex agent with all standard options enabled" {
+	export AGENTBOX_PROXY_IMAGE="ghcr.io/mattolson/agent-sandbox-proxy:latest"
+	export AGENTBOX_AGENT_IMAGE="ghcr.io/mattolson/agent-sandbox-codex:latest"
+	export AGENTBOX_ENABLE_SHELL_CUSTOMIZATIONS="true"
+	export AGENTBOX_ENABLE_DOTFILES="true"
+	export AGENTBOX_MOUNT_GIT_READONLY="true"
+	export AGENTBOX_MOUNT_IDEA_READONLY="true"
+	export AGENTBOX_MOUNT_VSCODE_READONLY="true"
+
+	unset -f pull_and_pin_image
+	stub pull_and_pin_image \
+		"ghcr.io/mattolson/agent-sandbox-proxy:latest : echo 'ghcr.io/mattolson/agent-sandbox-proxy@sha256:abc123'" \
+		"ghcr.io/mattolson/agent-sandbox-codex:latest : echo 'ghcr.io/mattolson/agent-sandbox-codex@sha256:jkl012'"
+
+	run devcontainer \
+		--policy-file "$POLICY_FILE" \
+		--project-path "$PROJECT_DIR" \
+		--agent "codex" \
+		--ide "vscode"
+	assert_success
+
+	run yq '.name' "$PROJECT_DIR/.devcontainer/docker-compose.yml"
+	assert_output "project-sandbox-devcontainer"
+
+	codex_agent_compose_file_has_expected_content "$PROJECT_DIR/.devcontainer/docker-compose.yml"
 
 	assert_devcontainer_volume "$PROJECT_DIR/.devcontainer/docker-compose.yml"
 }

--- a/docs/plan/milestones/m7-codex/milestone.md
+++ b/docs/plan/milestones/m7-codex/milestone.md
@@ -109,7 +109,7 @@ The proxy domain allowlist includes both OpenAI API domains and OAuth domains (`
 - `cli/templates/codex/devcontainer/docker-compose.yml`
 - `cli/templates/codex/devcontainer/devcontainer.json`
 - Named volumes: `codex-state` (for `~/.codex/`), `codex-history` (shell history)
-- Environment: `CODEX_HOME=/home/dev/.codex`, proxy settings, `GODEBUG=http2client=0`
+- Environment: proxy settings and `GODEBUG=http2client=0`
 - No agent-specific VS Code extension (Codex is CLI-only)
 - devcontainer.json name: "Codex CLI Sandbox"
 

--- a/docs/plan/milestones/m7-codex/tasks/m7.3-templates/execution-log.md
+++ b/docs/plan/milestones/m7-codex/tasks/m7.3-templates/execution-log.md
@@ -1,5 +1,11 @@
 # Execution Log: m7.3 - Codex CLI and Devcontainer Templates
 
+## 2026-03-06 - Follow-up cleanup
+
+Removed the redundant `CODEX_HOME=/home/dev/.codex` environment variable from both Codex compose templates. The state volume already mounts the default config directory, so the env var did not change behavior and only made the templates diverge from the cleaner Copilot baseline.
+
+**Decision:** Keep only proxy-related environment variables and `GODEBUG` in the Codex templates. Avoid restating tool defaults unless the image or entrypoint changes the expected config path.
+
 ## 2026-02-23 - Implementation complete
 
 Created all three template files by adapting the copilot templates:
@@ -12,10 +18,10 @@ Changes from copilot templates:
 - Image: `agent-sandbox-codex` (was `agent-sandbox-copilot`)
 - Volumes: `codex-state` at `/home/dev/.codex` (was `copilot-state` at `/home/dev/.copilot`)
 - Volumes: `codex-history` (was `copilot-history`)
-- Environment: added `CODEX_HOME=/home/dev/.codex`
+- Environment: kept proxy settings and `GODEBUG=http2client=0`
 - Volume comment: "Persist Codex config and credentials" (was "Persist Copilot credentials")
 - devcontainer.json: name "Codex CLI Sandbox", no `extensions` arrays (Codex is CLI-only)
 
 ## 2026-02-23 - Planning
 
-Reviewed all existing templates (Claude CLI, Claude devcontainer, Copilot CLI, Copilot devcontainer). Copilot is the closer analog since it has no agent-specific env vars beyond the standard proxy settings. Claude adds `CLAUDE_CONFIG_DIR` and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`.
+Reviewed all existing templates (Claude CLI, Claude devcontainer, Copilot CLI, Copilot devcontainer). Copilot is the closer analog since it has no agent-specific env vars beyond the standard proxy settings. Claude adds `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`.

--- a/docs/plan/milestones/m7-codex/tasks/m7.3-templates/task.md
+++ b/docs/plan/milestones/m7-codex/tasks/m7.3-templates/task.md
@@ -32,11 +32,11 @@ Create CLI and devcontainer compose templates and devcontainer.json for Codex.
 
 ### Approach
 
-Copy the copilot templates as a starting point (copilot is the closer match since it has no agent-specific env vars like Claude's `CLAUDE_CONFIG_DIR` and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`). Then adjust:
+Copy the copilot templates as a starting point (copilot is the closer match since it has no agent-specific env vars like Claude's `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`). Then adjust:
 
 1. **Image name**: `ghcr.io/mattolson/agent-sandbox-codex:latest`
 2. **Volume names**: `codex-state` (mounted at `/home/dev/.codex`), `codex-history`
-3. **Environment**: Add `CODEX_HOME=/home/dev/.codex`. Keep proxy settings and `GODEBUG=http2client=0`.
+3. **Environment**: Keep proxy settings and `GODEBUG=http2client=0`.
 4. **devcontainer.json**: Name "Codex CLI Sandbox", no extensions (Codex is CLI-only, no VS Code or JetBrains plugin). Keep JetBrains proxy settings (useful if someone opens the devcontainer in a JetBrains IDE for other reasons).
 5. **Comment**: "Codex CLI Sandbox" header
 
@@ -63,7 +63,7 @@ None. This is a mechanical adaptation of existing templates.
 
 ### Learnings
 
-- Codex templates are nearly identical to Copilot. The only substantive differences are image name, volume names, state directory path, and `CODEX_HOME` env var. Copilot has no agent-specific env vars either, making it the cleanest base to adapt from.
+- Codex templates are nearly identical to Copilot. The substantive differences are image name, volume names, and state directory path. Copilot has no agent-specific env vars either, making it the cleanest base to adapt from.
 
 ### Follow-up Items
 


### PR DESCRIPTION
# Summary

This removes two redundant environment variables from the generated compose templates:

- `CLAUDE_CONFIG_DIR=/home/dev/.claude`
- `CODEX_HOME=/home/dev/.codex`

Both variables were set to the tools' default config paths, so they did not change runtime behavior. Removing them keeps the templates simpler and reduces unnecessary drift between agents.

# Changes

- Remove `CLAUDE_CONFIG_DIR` from the Claude CLI and devcontainer compose templates
- Remove `CODEX_HOME` from the Codex CLI and devcontainer compose templates
- Update init regression coverage to assert those variables are absent
- Add Codex regression coverage so the template shape is explicitly tested
- Update the m7 Codex planning docs to match the current template contract

