### PR TITLE
Update uid for container users

### DIFF
--- a/.agent-sandbox/compose/agent.claude.yml
+++ b/.agent-sandbox/compose/agent.claude.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=claude
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-claude@sha256:0853780d4485fdd1cfe83eea1ef1e28a72de7ba8a8b01f3d88caeca616aae779
+    image: ghcr.io/mattolson/agent-sandbox-claude@sha256:665d30d42257bb1ac9c0e1738ec27e6f11238baf3f8ca322828404f9e3b29720
     volumes:
       # Persist Claude credentials
       - claude-state:/home/dev/.claude

--- a/.agent-sandbox/compose/agent.codex.yml
+++ b/.agent-sandbox/compose/agent.codex.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=codex
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-codex@sha256:21dc92cf71b218875f6770cedbb8b079dfcacde3006f329bde75b18099e00655
+    image: ghcr.io/mattolson/agent-sandbox-codex@sha256:24012c365111160139cb27138bf1c8cd88e64bf694f172b4c2424909d9872c56
     volumes:
       # Persist Codex config and credentials
       - codex-state:/home/dev/.codex

--- a/.agent-sandbox/compose/agent.gemini.yml
+++ b/.agent-sandbox/compose/agent.gemini.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=gemini
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-gemini@sha256:1c9697bf8ebc818355eb215a7f1dc3b557dca88fdcf4f83e90641e34c6a36e89
+    image: ghcr.io/mattolson/agent-sandbox-gemini@sha256:a1154de747037b0af1222a9c39686149393a7da46384d82eef5931d0ebb821a2
     volumes:
       # Persist Gemini credentials
       - gemini-state:/home/dev/.gemini

--- a/.agent-sandbox/compose/base.yml
+++ b/.agent-sandbox/compose/base.yml
@@ -4,7 +4,7 @@
 name: agent-sandbox
 services:
   proxy:
-    image: mattolson/agent-sandbox-proxy@sha256:e5e5dd7c24880f93f8901d995751e4e3f549ee7cbbd51c3fb105c3d05711cef4
+    image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:e5e5dd7c24880f93f8901d995751e4e3f549ee7cbbd51c3fb105c3d05711cef4
     cap_drop:
       - ALL
     environment:

--- a/.agent-sandbox/compose/base.yml
+++ b/.agent-sandbox/compose/base.yml
@@ -4,7 +4,7 @@
 name: agent-sandbox
 services:
   proxy:
-    image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:8a0e5922e20d0197a7229146e5fb0a05c0089903b09798aba232244ba180642b
+    image: mattolson/agent-sandbox-proxy@sha256:e5e5dd7c24880f93f8901d995751e4e3f549ee7cbbd51c3fb105c3d05711cef4
     cap_drop:
       - ALL
     environment:

--- a/.agent-sandbox/compose/user.agent.opencode.override.yml
+++ b/.agent-sandbox/compose/user.agent.opencode.override.yml
@@ -4,6 +4,7 @@
 # Claude examples:
 #   - ${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro
 #   - ${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro
-services:
-  agent:
-    volumes: []
+
+#services:
+#  agent:
+#    image: agent-sandbox-opencode:local

--- a/.agent-sandbox/policy/user.agent.opencode.policy.yaml
+++ b/.agent-sandbox/policy/user.agent.opencode.policy.yaml
@@ -5,6 +5,7 @@
 #
 # See docs/policy/schema.md for the full format reference.
 
+# Allow OpenCode to use Codex
 services:
   - codex
 domains: []

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Target platform: [Colima](https://github.com/abiosoft/colima) + [Docker Engine](
 
 You need a VM and Docker (along with docker-compose and docker-buildx) installed. This can be done in a variety of ways.
 
-* Colima
-* Podman
-* OrbStack
-* Docker Desktop
-* Rancher
+* [Colima](https://colima.run/)
+* [Podman](https://podman.io/)
+* [OrbStack](https://orbstack.dev/)
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+* [Rancher Desktop](https://rancherdesktop.io/)
 
 Instructions that follow are for Colima.
 
@@ -62,8 +62,8 @@ Instructions that follow are for Colima.
 # docker-buildx for building images locally
 brew install colima docker docker-compose docker-buildx
 
-# Start the virtual machine - see the colima docs for launching on boot
-colima start --cpu 4 --memory 8 --disk 60
+# Start the virtual machine
+colima start --edit
 ```
 
 ### 2. Install agent-sandbox CLI

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -69,9 +69,10 @@ RUN if [ -n "$EXTRA_PACKAGES" ]; then \
       && apt-get clean && rm -rf /var/lib/apt/lists/*; \
     fi
 
-# Set up non-root user
+# Set up non-root user using uid 501 to match default first user on MacOS
+# to avoid possible bind mount permission problems
 ARG USERNAME=dev
-RUN groupadd --system --gid 500 ${USERNAME} && useradd --system --create-home --uid 500 --gid 500 --shell /bin/bash ${USERNAME}
+RUN groupadd --system --gid 501 ${USERNAME} && useradd --system --create-home --uid 501 --gid 501 --shell /bin/bash ${USERNAME}
 
 # Persist shell history (docker volume)
 RUN mkdir /commandhistory \

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM mitmproxy/mitmproxy:latest
 
-# Match uid with the default first user on MacOS to avoid permission issues with mounts
-RUN usermod -u 501 mitmproxy
+# Match uid/gid with the default first user on MacOS to avoid permission issues with mounts
+RUN groupmod -g 501 mitmproxy && usermod -u 501 mitmproxy
 
 # nc used for docker compose health check
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,5 +1,8 @@
 FROM mitmproxy/mitmproxy:latest
 
+# Match uid with the default first user on MacOS to avoid permission issues with mounts
+RUN usermod -u 501 mitmproxy
+
 # nc used for docker compose health check
 RUN apt-get update && apt-get install -y --no-install-recommends \
   netcat-traditional \


### PR DESCRIPTION
Update the user id for the container users (`dev` for agent containers and `mitmproxy` for the proxy container) to 501, which is the default uid for the first user on a MacOS system. This helps prevent any permission errors when reading files that are mounted from the host if they are readable only to the owner.

Also included are a couple of minor unrelated changes:
- Bump the image versions for local dev environment
- Minor readme update