### PR TITLE
Release Go CLI

### DIFF
--- a/.github/workflows/release-go-binaries.yml
+++ b/.github/workflows/release-go-binaries.yml
@@ -33,6 +33,7 @@ jobs:
           fi
 
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "8649e57e96f97757a1a45e1af1b51f6cd2697bfa9e5e0ed7dcbc2e9ab90ac2f3  /usr/local/bin/yq" | sha256sum --check
           sudo chmod +x /usr/local/bin/yq
           yq --version
 

--- a/.github/workflows/release-go-binaries.yml
+++ b/.github/workflows/release-go-binaries.yml
@@ -1,0 +1,128 @@
+name: Release Go Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Ensure yq is available
+        run: |
+          if command -v yq >/dev/null 2>&1; then
+            yq --version
+            exit 0
+          fi
+
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Verify embedded templates are in sync
+        run: |
+          ./scripts/sync-go-templates.bash
+          git diff --exit-code -- internal/embeddata/templates
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Run Bash-vs-Go parity suite
+        run: ./scripts/parity.bash
+
+  build:
+    runs-on: ubuntu-latest
+    needs: verify
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release archives
+        run: ./scripts/build-release-artifacts.bash --version "${GITHUB_REF_NAME}" --out-dir dist/release
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-go-binaries
+          path: dist/release/*
+
+      - name: Summarize built archives
+        run: |
+          {
+            printf '## Go Release Artifacts\n\n'
+            printf 'Built from tag `%s`.\n\n' "${GITHUB_REF_NAME}"
+            printf '| Asset |\n'
+            printf '| --- |\n'
+            for asset in dist/release/*; do
+              printf '| `%s` |\n' "$(basename "$asset")"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  draft-release:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Download built archives
+        uses: actions/download-artifact@v4
+        with:
+          name: release-go-binaries
+          path: dist/release
+
+      - name: Create or update draft release
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            if [ "$(gh release view "$tag" --json isDraft --jq .isDraft)" != "true" ]; then
+              printf 'refusing to modify non-draft release %s\n' "$tag" >&2
+              exit 1
+            fi
+          else
+            gh release create "$tag" \
+              --draft \
+              --title "$tag" \
+              --target "${GITHUB_SHA}" \
+              --generate-notes
+          fi
+
+          gh release upload "$tag" dist/release/* --clobber
+
+      - name: Summarize draft release
+        run: |
+          url="$(gh release view "${GITHUB_REF_NAME}" --json url --jq .url)"
+          {
+            printf '## Draft Release Ready\n\n'
+            printf 'Draft release: %s\n' "$url"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Draft-first Go binary release flow.** Version tags now build macOS and Linux `agentbox` archives plus checksums and upload them to a draft GitHub release before human publication.
+- **Stable latest-download asset names.** Releases now include unversioned archives like `agentbox_linux_arm64.tar.gz` plus `agentbox_checksums.txt`, so users can install the latest binary for their architecture via GitHub's `releases/latest/download/...` shortcut.
+
+### Changed
+
+- **Go binary is now the primary documented install path.** README and CLI docs now point users to GitHub Releases binaries instead of telling them to clone `cli/bin`.
+- **Documented host-side `yq` requirement removed from the primary install flow.** The Go binary handles YAML and JSON natively, so users no longer need `brew install yq` just to install `agentbox`.
+- **Docker CLI image is now documented as a deprecated fallback.** The image remains available during the transition, but it is no longer presented as the primary way to install the CLI.
+
 ## [0.8.0] - 2026-03-14 (f422f7a)
 
 Agent switching without data loss, plus a new layered runtime model from `m8`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ colima start --edit
 
 ### 2. Install agent-sandbox CLI
 
-Download the `agentbox` binary from GitHub Releases.
+Download the `agentbox` binary from [GitHub Releases](https://github.com/mattolson/agent-sandbox/releases).
 
 #### GitHub Releases binary
 
@@ -105,12 +105,6 @@ agentbox init
 ```
 
 This prompts interactively for the project name, agent, mode, and IDE when needed, then generates the docker compose and network policy files for the sandbox.
-
-For scripted use, you can pass flags to skip the selection prompts. Use `--batch` to disable all prompts:
-
-```bash
-agentbox init --batch --agent claude --mode cli
-```
 
 See the [CLI README](cli/README.md) for the full list of commands, flags, and environment variables.
 

--- a/README.md
+++ b/README.md
@@ -68,31 +68,35 @@ colima start --edit
 
 ### 2. Install agent-sandbox CLI
 
-The [CLI](cli/README.md) is a set of helper scripts that simplify the process of initializing and managing the sandbox.
+Download the `agentbox` binary from GitHub Releases.
 
-#### Local install (recommended)
-
-```bash
-# Clone the repo
-git clone https://github.com/mattolson/agent-sandbox.git
-
-# Add agenbox bin directory to your path (add this to your .bashrc or .zshrc)
-export PATH="$PWD/agent-sandbox/cli/bin:$PATH"
-```
-
-`yq` is required for certain CLI functionality. Install with `brew install yq`.
-
-#### Run through docker image
-
-You can also run the agentbox CLI through a published docker image if you don't want to install anything locally:
+#### GitHub Releases binary
 
 ```bash
-# Pull the image to local docker
-docker pull ghcr.io/mattolson/agent-sandbox-cli
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
 
-# Add to your .bashrc or .zshrc
-alias agentbox='docker run --rm -it -v "/var/run/docker.sock:/var/run/docker.sock" -v"$PWD:$PWD" -w"$PWD" -e TERM -e HOME --network none ghcr.io/mattolson/agent-sandbox-cli'
+case "$ARCH" in
+  x86_64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+ASSET="agentbox_${OS}_${ARCH}.tar.gz"
+
+cd /tmp
+curl -fsSLO \
+  "https://github.com/mattolson/agent-sandbox/releases/latest/download/${ASSET}"
+tar -xzf "${ASSET}"
+sudo install "/tmp/agentbox_${OS}_${ARCH}/agentbox" /usr/local/bin/agentbox
+agentbox version
 ```
+
+If you want to verify the archive before installing it, download `agentbox_checksums.txt` from the same release and
+compare the checksum for `${ASSET}` against `shasum -a 256 "${ASSET}"` on macOS or `sha256sum "${ASSET}"` on Linux.
+
+If you want a pinned install instead of "latest", use the versioned assets attached to a specific release tag such as
+`agentbox_<version>_<os>_<arch>.tar.gz` together with `agentbox_<version>_checksums.txt`.
 
 ### 3. Initialize the sandbox for your project
 
@@ -108,7 +112,7 @@ For scripted use, you can pass flags to skip the selection prompts. Use `--batch
 agentbox init --batch --agent claude --mode cli
 ```
 
-See the [CLI README](cli/README.md) for the full list of flags and environment variables.
+See the [CLI README](cli/README.md) for the full list of commands, flags, and environment variables.
 
 To inspect the configuration after init, use `agentbox policy config` to output the effective network policy and
 `agentbox compose config` for the fully combined docker compose stack.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,25 @@
 # Agent Sandbox CLI
 
-Command-line tool for managing agent-sandbox configurations and Docker Compose setups.
+Install `agentbox` from GitHub Releases. See the [main README](../README.md#2-install-agent-sandbox-cli) for the
+download steps.
 
-Requires `docker` (and `docker compose`) and [`yq`](https://github.com/mikefarah/yq).
+This document is the command reference for the current `agentbox` surface and the maintenance guide for the legacy Bash
+implementation that still lives under `cli/` during the transition. That legacy path still depends on `docker`, `docker
+compose`, and [`yq`](https://github.com/mikefarah/yq).
+
+## Docker Image Fallback
+
+The old Docker CLI image is still available during the transition:
+
+```bash
+docker pull ghcr.io/mattolson/agent-sandbox-cli
+alias agentbox='docker run --rm -it -v "/var/run/docker.sock:/var/run/docker.sock" -v"$PWD:$PWD" -w"$PWD" -e TERM -e HOME --network none ghcr.io/mattolson/agent-sandbox-cli'
+```
+
+Tradeoffs:
+- Commands such as `agentbox edit policy` use `vi` inside the container rather than your host editor
+- Host environment variables are not automatically visible to Docker Compose unless you forward them explicitly
+- The image remains on the old CLI implementation until follow-up work removes that path
 
 ## Modules and Commands
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -30,6 +30,8 @@ codex
 codex --full-auto
 ```
 
+The image includes system `bubblewrap` so Codex's Linux startup check finds `/usr/bin/bwrap` and does not warn at launch. Codex still defaults to `danger-full-access` via the baked-in config, with isolation handled by the surrounding container, proxy, and firewall.
+
 Afterward, for CLI mode, stop the container:
 
 ```bash

--- a/docs/plan/learnings.md
+++ b/docs/plan/learnings.md
@@ -26,6 +26,8 @@ Lessons learned during project execution. Review at the start of each planning s
 - Shared shell helpers that use `mapfile` must source `compat.bash` or macOS Bash 3.2 support regresses silently
 - `runtime/debug.ReadBuildInfo` exposes VCS revision, timestamp, and dirty state for local Go builds in a checkout, so early Go CLIs can print useful version metadata without depending on a generated `.version` file
 - Shell-escaped state files written with Bash `%q` can be parsed safely in Go with a shell-style splitter instead of sourcing them
+- `go version -m` is a practical way to validate embedded build metadata in cross-compiled Go release binaries without having to execute every target artifact on the current host
+- Stable `releases/latest/download/...` URLs require stable artifact names and stable archive contents; an unversioned filename is not enough if the tarball still unpacks into a versioned directory
 
 ## Architecture
 
@@ -63,3 +65,4 @@ Lessons learned during project execution. Review at the start of each planning s
 - Native scaffold refresh helpers can safely power lifecycle commands as long as they only rewrite agentbox-managed layers and never overwrite user-owned override or policy files during sync
 - Bash `edit` flows are not fully batch-friendly because `open_editor` binds stdio to `/dev/tty`; parity automation needs a pseudo-tty when exercising the real Bash path
 - Bash edit commands use second-resolution mtimes for change detection, so parity fixtures need a deliberate delay before writing file changes or real edits may be misclassified as unchanged
+- Draft-first binary release workflows are safer than publishing first and attaching assets later because they avoid public releases with missing or partial artifacts while keeping the tag as the build source of truth

--- a/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/execution-log.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/execution-log.md
@@ -1,5 +1,39 @@
 # Execution Log: m13.6 - Release Cutover And Docs
 
+## 2026-04-09 03:52 UTC - Simplified install copy for first-time readers
+
+Removed rollout phrasing like "primary supported install path" and "(recommended)" from the GitHub Releases install copy in `README.md`, and simplified the top of `cli/README.md` so it reads as a straightforward install-reference handoff instead of internal migration language.
+
+## 2026-04-09 03:48 UTC - Simplified top-level install docs
+
+Removed the deprecated Docker-image fallback section from `README.md` so the top-level install story now shows only the Go binary path, and moved that fallback discussion into `cli/README.md` instead.
+
+**Decision:** Keep the main README singular about installation. The deprecated Docker image is still relevant, but it belongs in the CLI reference and troubleshooting surfaces rather than beside the primary install path.
+
+## 2026-04-09 03:40 UTC - Added stable latest-download asset names
+
+Extended `scripts/build-release-artifacts.bash` so each release now emits both versioned archives such as `agentbox_0.8.0_linux_arm64.tar.gz` and stable unversioned archives such as `agentbox_linux_arm64.tar.gz`, plus a stable `agentbox_checksums.txt` manifest. Updated `README.md` to use the unversioned `releases/latest/download/...` path for the convenience install flow.
+
+Local verification passed by rebuilding `/tmp/agentbox-release-test`, confirming the unversioned assets exist, extracting `agentbox_linux_arm64.tar.gz`, and running the extracted binary's `version` command successfully.
+
+**Issue:** Publishing only versioned archive names meant users could not use GitHub's `releases/latest/download/<asset>` shortcut without first resolving the latest tag. A naive copy to an unversioned tarball name was also insufficient because the archive still unpacked into a versioned directory.
+**Solution:** Emit a second set of archives with stable filenames and stable unpack paths, and add a matching stable checksum manifest for those assets.
+
+**Learning:** Stable download URLs require stable artifact names and stable archive contents. Convenience assets need to be designed intentionally rather than derived as a last-minute copy of versioned outputs.
+
+## 2026-04-08 05:25 UTC - Release workflow, packaging helper, and docs cutover implemented
+
+Added `scripts/build-release-artifacts.bash` to build tagged macOS and Linux archives with checksum output and explicit `ldflags` version metadata, added `.github/workflows/release-go-binaries.yml` to run Go tests plus parity before creating or updating a draft GitHub release on version tags, and updated `README.md`, `cli/README.md`, `docs/troubleshooting.md`, `docs/roadmap.md`, and `CHANGELOG.md` so GitHub Releases binaries are the primary install path and the Docker CLI image is only a deprecated fallback.
+
+Local verification passed with `bash -n scripts/build-release-artifacts.bash`, `go test ./...`, `./scripts/parity.bash`, `scripts/build-release-artifacts.bash --version v0.8.0 --out-dir /tmp/agentbox-release-test`, checksum verification of the native archive, `agentbox version` from the extracted binary, and `agentbox init --batch` from that extracted binary against a temp repo using local image refs.
+
+**Issue:** The first packaging-helper smoke test failed because it assumed the version command printed `agentbox <version>` and because local dirty-worktree builds legitimately gained a `-dirty` suffix.
+**Solution:** Relax the smoke check to assert the expected version string and `source: ldflags` instead of one exact command banner, and allow local verification to override `BUILD_DIRTY=false` when simulating a clean release build.
+
+**Decision:** Keep release packaging logic in a small repo-owned shell helper plus one dedicated workflow, and keep the old Docker CLI image untouched for `m13.6` rather than mixing distribution cutover with fallback implementation changes.
+
+**Learning:** `go version -m` provides a lightweight metadata validation path for cross-compiled release artifacts, which makes it practical to sanity-check all four target binaries even though only the native host-target pair can be executed directly in local verification.
+
 ## 2026-04-07 05:48 UTC - Deprecated fallback stays unchanged for m13.6
 
 Chose to keep the deprecated Docker CLI fallback as-is for `m13.6`. This task will cut over the primary distribution path to GitHub Releases binaries and documentation, but it will not repoint `images/cli/Dockerfile` at the Go binary or start removing the old Bash CLI yet.

--- a/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/execution-log.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/execution-log.md
@@ -1,0 +1,14 @@
+# Execution Log: m13.6 - Release Cutover And Docs
+
+## 2026-04-07 05:46 UTC - Planning complete
+
+Reviewed the `m13.6` section of `docs/plan/milestones/m13-go-cli-rewrite/milestone.md`, `docs/plan/project.md`, `docs/plan/learnings.md`, decision `004`, the completed `m13.4` and `m13.5` task artifacts, the current Go CI and parity workflows in `.github/workflows/go-tests.yml` and `.github/workflows/parity-tests.yml`, the current image-publishing workflow in `.github/workflows/build-images.yml`, the existing Bash CLI image in `images/cli/Dockerfile`, and the user-facing install/docs surfaces in `README.md`, `cli/README.md`, `docs/troubleshooting.md`, `docs/roadmap.md`, and `CHANGELOG.md`.
+
+The main planning conclusion is that `m13.6` should add a dedicated Go-binary release workflow and then do a documentation cutover around that artifact. The Go binary should become the primary install path in docs and releases, while the Docker CLI image remains available only as a clearly deprecated fallback during the transition. The Bash implementation should stay in-repo as the parity oracle until the new release path has shipped successfully.
+
+**Issue:** The repo still tells users to clone `cli/bin`, install host `yq`, or pull `ghcr.io/mattolson/agent-sandbox-cli`, even though the Go rewrite now covers the full command surface and parity gates exist.
+**Solution:** Plan `m13.6` as a combined release-automation plus documentation cutover task. Add a dedicated workflow for tagged Go binary releases with checksums, then update README, CLI docs, troubleshooting, changelog, and roadmap together so the primary install story changes in one move.
+
+**Decision:** Recommend a dedicated Go-binary release workflow instead of extending the existing image workflow. The artifact model, version stamping, and user-facing output are different enough that keeping release assets separate from GHCR image publishing will make the cutover clearer and easier to maintain.
+
+**Learning:** Distribution cutovers fail when the code is ready but the docs and release machinery still point at the previous path. For `m13.6`, the highest-risk drift is between release automation and user-facing install guidance, not between the Go and Bash command semantics.

--- a/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/execution-log.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/execution-log.md
@@ -1,5 +1,21 @@
 # Execution Log: m13.6 - Release Cutover And Docs
 
+## 2026-04-07 05:48 UTC - Deprecated fallback stays unchanged for m13.6
+
+Chose to keep the deprecated Docker CLI fallback as-is for `m13.6`. This task will cut over the primary distribution path to GitHub Releases binaries and documentation, but it will not repoint `images/cli/Dockerfile` at the Go binary or start removing the old Bash CLI yet.
+
+**Decision:** Leave the fallback image and old CLI implementation unchanged during `m13.6`, and create follow-up work to remove the old CLI and decide whether the fallback image should switch codepaths first or disappear entirely.
+
+**Rationale:** Mixing distribution cutover, fallback-image implementation changes, and legacy CLI removal in one task would blur the acceptance boundary and raise rollback risk. Keeping the fallback untouched makes `m13.6` narrower: ship the Go binary, update the docs, and deprecate the old path without changing its runtime behavior.
+
+## 2026-04-07 05:47 UTC - Release trigger direction chosen
+
+Chose the two-step release model for `m13.6`: tag push builds versioned archives and checksums, uploads them to a draft or otherwise unpublished GitHub release, and a separate human publish step makes the release public after notes and assets are confirmed.
+
+**Decision:** Use a two-step release flow instead of triggering binary packaging from `release.published`. The tag remains the build source of truth, but publication waits until artifacts exist.
+
+**Rationale:** This avoids the main failure mode of `release.published`: a public release page with missing or partial assets if packaging fails halfway through. It also keeps recovery simpler because draft assets can be rebuilt or re-uploaded without retagging.
+
 ## 2026-04-07 05:46 UTC - Planning complete
 
 Reviewed the `m13.6` section of `docs/plan/milestones/m13-go-cli-rewrite/milestone.md`, `docs/plan/project.md`, `docs/plan/learnings.md`, decision `004`, the completed `m13.4` and `m13.5` task artifacts, the current Go CI and parity workflows in `.github/workflows/go-tests.yml` and `.github/workflows/parity-tests.yml`, the current image-publishing workflow in `.github/workflows/build-images.yml`, the existing Bash CLI image in `images/cli/Dockerfile`, and the user-facing install/docs surfaces in `README.md`, `cli/README.md`, `docs/troubleshooting.md`, `docs/roadmap.md`, and `CHANGELOG.md`.

--- a/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/task.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/task.md
@@ -45,7 +45,7 @@ Make the Go binary the supported distribution path and update project docs, CI, 
 - `docs/troubleshooting.md` - update the Docker CLI image section so it is explicitly a deprecated fallback and add any binary-install troubleshooting that becomes necessary during execution
 - `CHANGELOG.md` - add an unreleased or release entry documenting the Go-binary cutover, removal of documented host `yq` dependency, and deprecated Docker CLI fallback
 - `docs/roadmap.md` - update the m13 summary so it reflects Go binary distribution as the primary path rather than the old Docker CLI image
-- `images/cli/Dockerfile` - only if the fallback image needs a minimal update to wrap or invoke the Go binary instead of the Bash tree; avoid broad image churn unless required by the chosen fallback design
+- `images/cli/Dockerfile` - not expected to change in `m13.6`; keep the deprecated fallback image as-is for this transition task and defer any switch or removal to follow-up work
 - `docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/*.md` - living task plan and execution log
 
 ### Approach
@@ -56,27 +56,24 @@ Use a dedicated Go-binary release workflow rather than overloading `build-images
 
 Prefer plain GitHub Actions plus a small repo-owned packaging script over introducing GoReleaser in this task. GoReleaser would solve the mechanics, but it would also add a substantial new config surface right at cutover time. This repo already leans on explicit shell and workflow scripts for build logic, and the required artifact matrix is narrow. Unless implementation proves unexpectedly awkward, a small packaging helper plus a focused workflow is the lower-risk option. If that assumption turns out wrong during execution, capture the tradeoff explicitly before adding a new release tool.
 
-The release workflow should build `agentbox` for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`, stamp each binary with version metadata derived from the tag and commit, archive them under a stable naming convention, generate a checksum manifest, and upload the assets to the tagged GitHub release. It should also run a minimal smoke check on each built binary, at least `agentbox version`, before publishing. It does not need to rerun the entire parity suite if the branch protections already require that before merge, but it should not create a path where a maintainer can publish a tag from an unvalidated commit without noticing.
+Use a two-step release flow. Step one should trigger on a version-tag push, build `agentbox` for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`, stamp each binary with version metadata derived from the tag and commit, archive them under a stable naming convention, generate a checksum manifest, run at least a minimal smoke check such as `agentbox version`, and upload the assets to a draft GitHub release or an equivalent unpublished release shell. Step two is the human publish action after assets and notes are ready. This keeps the tag as the build source of truth while avoiding a public release page with missing or partial assets. It does not need to rerun the entire parity suite if the branch protections already require that before merge, but it should not create a path where a maintainer can publish a tag from an unvalidated commit without noticing.
 
 For documentation, change the default narrative everywhere that currently points users to the Bash checkout or Docker CLI image. README should show direct binary download and PATH setup as the recommended path, remove the host `yq` prerequisite, and move the Docker image to a clearly marked fallback subsection with its tradeoffs. `cli/README.md` should stop reading like the primary install guide and instead become a command reference plus maintenance note for the legacy Bash path that still exists for parity and fallback. `docs/troubleshooting.md` should be updated to reflect that the Docker CLI image is now exceptional rather than normal. `CHANGELOG.md` and `docs/roadmap.md` should make the cutover explicit so the repo history and roadmap do not keep advertising the old distribution model.
 
-Be careful about what "clean up Bash-only distribution plumbing" means. The wrong interpretation is deleting `cli/`, `cli-tests.yml`, or the parity harness as soon as the first binary workflow lands. The right interpretation is removing Bash-first install guidance and any release-path machinery that makes the Bash or Docker image look like the primary user distribution. Keep the Bash implementation in-repo as the oracle until a released Go-first path has been validated in practice. The Docker CLI image should remain buildable and documented only as a deprecated fallback until a later task deliberately removes it.
+Be careful about what "clean up Bash-only distribution plumbing" means. The wrong interpretation is deleting `cli/`, `cli-tests.yml`, or the parity harness as soon as the first binary workflow lands. The right interpretation is removing Bash-first install guidance and any release-path machinery that makes the Bash or Docker image look like the primary user distribution. Keep the Bash implementation in-repo as the oracle until a released Go-first path has been validated in practice. For `m13.6`, keep the Docker CLI image build and implementation path unchanged and document it only as a deprecated fallback. Any switch of that image to the Go binary, or removal of the old CLI entirely, belongs in explicit follow-up work.
 
 ### Implementation Steps
 
-- [ ] Confirm the release artifact contract: file naming, archive format, checksum format, tag pattern, and whether release upload attaches to pre-created GitHub releases or creates them directly from the workflow
+- [ ] Confirm the release artifact contract: file naming, archive format, checksum format, tag pattern, and the exact two-step mechanics for creating a draft release on tag push before human publication
 - [ ] Add a dedicated Go-binary release workflow, plus a small packaging helper script if that materially reduces duplication across matrix jobs
 - [ ] Wire release-time version stamping through `-ldflags` and add or extend tests/smoke checks so downloaded binaries report stable release metadata
 - [ ] Add release verification that exercises the built binary through at least `agentbox version` and one documented install-flow smoke path
 - [ ] Rewrite README install guidance around GitHub Releases binaries, remove documented host `yq` dependency, and move the Docker CLI image to an explicitly deprecated fallback section
 - [ ] Update `cli/README.md`, `docs/troubleshooting.md`, `CHANGELOG.md`, and `docs/roadmap.md` so they all reflect the same Go-first distribution story and the same fast-follow deferrals
-- [ ] Decide whether the deprecated Docker CLI image should stay Bash-backed temporarily or should wrap the Go binary; implement only the minimum change needed to keep the fallback honest and working
 - [ ] Verify the release workflow in a non-destructive way if possible, then run `go test ./...`, `go build ./cmd/agentbox`, and a local binary-install smoke test that follows the updated docs
 
 ### Open Questions
 
-- Should the release workflow trigger on tag push, on `release.published`, or as a two-step flow where one event creates the release shell and the other uploads assets? The choice affects how easy it is to recover from failed uploads without retagging.
-- Do we want the deprecated Docker CLI fallback to continue shipping the Bash tree for one transition release, or should `images/cli/Dockerfile` pivot immediately to running the Go binary inside the image so fallback users also exercise the new codepath?
 - Is a dedicated upgrade note needed for users currently relying on `cli/bin/agentbox` in PATH, or are README plus changelog updates sufficient for this release?
 
 ## Outcome
@@ -97,4 +94,4 @@ Pending execution.
 
 ### Follow-up Items
 
-Pending execution.
+- Plan a follow-up task to remove the old Bash CLI distribution path and decide whether the deprecated Docker CLI image should switch to the Go binary first or be removed entirely.

--- a/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/task.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/task.md
@@ -1,0 +1,100 @@
+# Task: m13.6 - Release Cutover And Docs
+
+## Summary
+
+Make the Go binary the supported distribution path and update project docs, CI, and release automation to match.
+
+## Scope
+
+- Add build and release automation for macOS and Linux Go binaries (`amd64`, `arm64`)
+- Publish versioned GitHub release archives plus checksums for the supported platforms
+- Update installation and upgrade docs to use direct binary downloads from GitHub Releases as the primary install path instead of the Docker CLI image and host `yq`
+- Keep the Docker CLI image path as a clearly deprecated fallback during the transition instead of removing it immediately
+- Switch the repo's primary `agentbox` implementation path to the Go binary once parity gates are already in place
+- Clean up obsolete Bash-only distribution guidance after the first Go release path is validated, without removing the Bash oracle needed by parity
+- Explicitly defer Homebrew packaging and installer-script automation to fast-follow work after the binary release path is stable
+
+## Acceptance Criteria
+
+- [ ] A tagged release produces downloadable archives and checksums for all supported platforms and architectures
+- [ ] README, `cli/README.md`, troubleshooting docs, and changelog document manual binary install from GitHub Releases as the primary path and no longer instruct users to install `yq`
+- [ ] The Go binary can manage a project end-to-end using the documented install flow
+- [ ] The Docker CLI image path remains available only as a clearly deprecated fallback during the transition
+- [ ] Homebrew and installer-script work are called out as fast-follow, not hidden inside m13 scope
+
+## Applicable Learnings
+
+- The Bash CLI and its tests are still the best behavioral oracle, so cutover should change distribution and documentation first, not remove the Bash implementation or parity workflow prematurely.
+- Native YAML and JSON handling are already in place in the Go CLI, so user-facing install docs should stop teaching a host-side `yq` prerequisite once the Go binary becomes primary.
+- Strong ownership boundaries matter more than matching one exact YAML byte shape; release verification should use end-to-end CLI behavior over the documented install flow, not just artifact creation.
+- The parity workflow is now a dedicated third CI layer. `m13.6` should keep that visible until at least one successful Go-first release has shipped and the fallback story has been exercised.
+- Documentation cutovers fail when they leave old install paths half-alive. If README, CLI docs, troubleshooting, roadmap, and changelog disagree, users will keep following the stale Bash or Docker image guidance.
+- The repo already has version metadata support via `internal/version` and existing GitHub Actions patterns for image publishing, so release work should reuse those seams instead of inventing a second metadata story.
+
+## Plan
+
+### Files Involved
+
+- `.github/workflows/release-go-binaries.yml` - new workflow to build, archive, checksum, and publish Go release assets for macOS and Linux on version tags
+- `.github/workflows/go-tests.yml` and/or `.github/workflows/parity-tests.yml` - adjust triggers or references only if needed so the release path clearly depends on the existing parity gates rather than bypassing them
+- `.github/workflows/build-images.yml` - keep the Docker CLI image path available, but update any release-facing naming or summary text if needed so it is clearly a deprecated fallback rather than the primary distribution artifact
+- `cmd/agentbox/main.go` and `internal/version/version.go` - verify or minimally extend release-time version stamping via `-ldflags` so downloaded binaries report a stable release version, commit, timestamp, and dirty state source
+- `scripts/build-release-artifacts.bash` or similar helper - optional shared packaging logic for archive naming, checksum generation, and local smoke verification if the workflow becomes too large to keep inline
+- `README.md` - replace clone-`cli/bin` and `yq` install guidance with GitHub Releases binary install instructions, plus the deprecated Docker-image fallback note
+- `cli/README.md` - rewrite the top-level framing so this document describes the command surface and legacy Bash/developer context, while pointing end users to the Go binary install path
+- `docs/troubleshooting.md` - update the Docker CLI image section so it is explicitly a deprecated fallback and add any binary-install troubleshooting that becomes necessary during execution
+- `CHANGELOG.md` - add an unreleased or release entry documenting the Go-binary cutover, removal of documented host `yq` dependency, and deprecated Docker CLI fallback
+- `docs/roadmap.md` - update the m13 summary so it reflects Go binary distribution as the primary path rather than the old Docker CLI image
+- `images/cli/Dockerfile` - only if the fallback image needs a minimal update to wrap or invoke the Go binary instead of the Bash tree; avoid broad image churn unless required by the chosen fallback design
+- `docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/*.md` - living task plan and execution log
+
+### Approach
+
+Treat `m13.6` as a release-path cutover, not as a packaging free-for-all. The key deliverable is a repeatable GitHub release flow that emits archives and checksums for the supported OS/architecture matrix and produces binaries with explicit version metadata via `-ldflags`. The repo already has the needed ingredients: a working Go CLI, existing CI gates (`go-tests`, Bash tests, parity), and a version package that accepts release-time metadata. The task should connect those pieces with the smallest possible amount of new release plumbing.
+
+Use a dedicated Go-binary release workflow rather than overloading `build-images.yml`. The image workflow is already long and organized around GHCR publishing, while `m13.6` needs a different artifact model: zipped or tarred binaries plus a checksum file attached to a GitHub release. A separate workflow keeps the boundary clear: one pipeline publishes runtime images, another publishes the primary host install artifact. That also makes the deprecation story honest. The Docker CLI image can continue to exist during the transition, but it should stop looking like the main thing we ship.
+
+Prefer plain GitHub Actions plus a small repo-owned packaging script over introducing GoReleaser in this task. GoReleaser would solve the mechanics, but it would also add a substantial new config surface right at cutover time. This repo already leans on explicit shell and workflow scripts for build logic, and the required artifact matrix is narrow. Unless implementation proves unexpectedly awkward, a small packaging helper plus a focused workflow is the lower-risk option. If that assumption turns out wrong during execution, capture the tradeoff explicitly before adding a new release tool.
+
+The release workflow should build `agentbox` for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`, stamp each binary with version metadata derived from the tag and commit, archive them under a stable naming convention, generate a checksum manifest, and upload the assets to the tagged GitHub release. It should also run a minimal smoke check on each built binary, at least `agentbox version`, before publishing. It does not need to rerun the entire parity suite if the branch protections already require that before merge, but it should not create a path where a maintainer can publish a tag from an unvalidated commit without noticing.
+
+For documentation, change the default narrative everywhere that currently points users to the Bash checkout or Docker CLI image. README should show direct binary download and PATH setup as the recommended path, remove the host `yq` prerequisite, and move the Docker image to a clearly marked fallback subsection with its tradeoffs. `cli/README.md` should stop reading like the primary install guide and instead become a command reference plus maintenance note for the legacy Bash path that still exists for parity and fallback. `docs/troubleshooting.md` should be updated to reflect that the Docker CLI image is now exceptional rather than normal. `CHANGELOG.md` and `docs/roadmap.md` should make the cutover explicit so the repo history and roadmap do not keep advertising the old distribution model.
+
+Be careful about what "clean up Bash-only distribution plumbing" means. The wrong interpretation is deleting `cli/`, `cli-tests.yml`, or the parity harness as soon as the first binary workflow lands. The right interpretation is removing Bash-first install guidance and any release-path machinery that makes the Bash or Docker image look like the primary user distribution. Keep the Bash implementation in-repo as the oracle until a released Go-first path has been validated in practice. The Docker CLI image should remain buildable and documented only as a deprecated fallback until a later task deliberately removes it.
+
+### Implementation Steps
+
+- [ ] Confirm the release artifact contract: file naming, archive format, checksum format, tag pattern, and whether release upload attaches to pre-created GitHub releases or creates them directly from the workflow
+- [ ] Add a dedicated Go-binary release workflow, plus a small packaging helper script if that materially reduces duplication across matrix jobs
+- [ ] Wire release-time version stamping through `-ldflags` and add or extend tests/smoke checks so downloaded binaries report stable release metadata
+- [ ] Add release verification that exercises the built binary through at least `agentbox version` and one documented install-flow smoke path
+- [ ] Rewrite README install guidance around GitHub Releases binaries, remove documented host `yq` dependency, and move the Docker CLI image to an explicitly deprecated fallback section
+- [ ] Update `cli/README.md`, `docs/troubleshooting.md`, `CHANGELOG.md`, and `docs/roadmap.md` so they all reflect the same Go-first distribution story and the same fast-follow deferrals
+- [ ] Decide whether the deprecated Docker CLI image should stay Bash-backed temporarily or should wrap the Go binary; implement only the minimum change needed to keep the fallback honest and working
+- [ ] Verify the release workflow in a non-destructive way if possible, then run `go test ./...`, `go build ./cmd/agentbox`, and a local binary-install smoke test that follows the updated docs
+
+### Open Questions
+
+- Should the release workflow trigger on tag push, on `release.published`, or as a two-step flow where one event creates the release shell and the other uploads assets? The choice affects how easy it is to recover from failed uploads without retagging.
+- Do we want the deprecated Docker CLI fallback to continue shipping the Bash tree for one transition release, or should `images/cli/Dockerfile` pivot immediately to running the Go binary inside the image so fallback users also exercise the new codepath?
+- Is a dedicated upgrade note needed for users currently relying on `cli/bin/agentbox` in PATH, or are README plus changelog updates sufficient for this release?
+
+## Outcome
+
+Pending execution.
+
+### Acceptance Verification
+
+- [ ] A tagged release produces downloadable archives and checksums for all supported platforms and architectures
+- [ ] README, `cli/README.md`, troubleshooting docs, and changelog document manual binary install from GitHub Releases as the primary path and no longer instruct users to install `yq`
+- [ ] The Go binary can manage a project end-to-end using the documented install flow
+- [ ] The Docker CLI image path remains available only as a clearly deprecated fallback during the transition
+- [ ] Homebrew and installer-script work are called out as fast-follow, not hidden inside m13 scope
+
+### Learnings
+
+Pending execution.
+
+### Follow-up Items
+
+Pending execution.

--- a/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/task.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/tasks/m13.6-release-cutover-and-docs/task.md
@@ -64,34 +64,42 @@ Be careful about what "clean up Bash-only distribution plumbing" means. The wron
 
 ### Implementation Steps
 
-- [ ] Confirm the release artifact contract: file naming, archive format, checksum format, tag pattern, and the exact two-step mechanics for creating a draft release on tag push before human publication
-- [ ] Add a dedicated Go-binary release workflow, plus a small packaging helper script if that materially reduces duplication across matrix jobs
-- [ ] Wire release-time version stamping through `-ldflags` and add or extend tests/smoke checks so downloaded binaries report stable release metadata
-- [ ] Add release verification that exercises the built binary through at least `agentbox version` and one documented install-flow smoke path
-- [ ] Rewrite README install guidance around GitHub Releases binaries, remove documented host `yq` dependency, and move the Docker CLI image to an explicitly deprecated fallback section
-- [ ] Update `cli/README.md`, `docs/troubleshooting.md`, `CHANGELOG.md`, and `docs/roadmap.md` so they all reflect the same Go-first distribution story and the same fast-follow deferrals
-- [ ] Verify the release workflow in a non-destructive way if possible, then run `go test ./...`, `go build ./cmd/agentbox`, and a local binary-install smoke test that follows the updated docs
+- [x] Confirm the release artifact contract: file naming, archive format, checksum format, tag pattern, and the exact two-step mechanics for creating a draft release on tag push before human publication
+- [x] Add a dedicated Go-binary release workflow, plus a small packaging helper script if that materially reduces duplication across matrix jobs
+- [x] Wire release-time version stamping through `-ldflags` and add or extend tests/smoke checks so downloaded binaries report stable release metadata
+- [x] Add release verification that exercises the built binary through at least `agentbox version` and one documented install-flow smoke path
+- [x] Rewrite README install guidance around GitHub Releases binaries, remove documented host `yq` dependency, and move the Docker CLI image to an explicitly deprecated fallback section
+- [x] Update `cli/README.md`, `docs/troubleshooting.md`, `CHANGELOG.md`, and `docs/roadmap.md` so they all reflect the same Go-first distribution story and the same fast-follow deferrals
+- [x] Verify the release workflow in a non-destructive way if possible, then run `go test ./...`, `go build ./cmd/agentbox`, and a local binary-install smoke test that follows the updated docs
 
 ### Open Questions
 
-- Is a dedicated upgrade note needed for users currently relying on `cli/bin/agentbox` in PATH, or are README plus changelog updates sufficient for this release?
+None after implementation. README plus changelog updates are sufficient for this release cutover; if users report migration confusion, add a dedicated upgrade note in follow-up work rather than widening `m13.6`.
 
 ## Outcome
 
-Pending execution.
+Implemented a draft-first Go binary release path with a reusable packaging helper and a dedicated GitHub Actions workflow that runs Go tests plus parity before creating or updating a draft release for version tags. The packaging helper builds macOS and Linux archives, injects explicit `ldflags` version metadata, includes `LICENSE`, emits versioned checksum manifests, and also emits stable unversioned archives plus `agentbox_checksums.txt` so `releases/latest/download/...` works cleanly for a given OS and architecture. User-facing docs now point to GitHub Releases binaries as the primary install path, remove the documented host-side `yq` dependency from that path, and demote the Docker CLI image to an explicitly deprecated fallback without changing its implementation.
 
 ### Acceptance Verification
 
-- [ ] A tagged release produces downloadable archives and checksums for all supported platforms and architectures
-- [ ] README, `cli/README.md`, troubleshooting docs, and changelog document manual binary install from GitHub Releases as the primary path and no longer instruct users to install `yq`
-- [ ] The Go binary can manage a project end-to-end using the documented install flow
-- [ ] The Docker CLI image path remains available only as a clearly deprecated fallback during the transition
-- [ ] Homebrew and installer-script work are called out as fast-follow, not hidden inside m13 scope
+- [ ] A tagged release produces downloadable archives and checksums for all supported platforms and architectures.
+  Implemented in `.github/workflows/release-go-binaries.yml` and `scripts/build-release-artifacts.bash`, but not yet exercised from a real GitHub tag in Actions.
+- [x] README, `cli/README.md`, troubleshooting docs, and changelog document manual binary install from GitHub Releases as the primary path and no longer instruct users to install `yq`.
+  Verified in `README.md`, `cli/README.md`, `docs/troubleshooting.md`, and `CHANGELOG.md`.
+- [x] The Go binary can manage a project end-to-end using the documented install flow.
+  Verified locally by building release archives with `scripts/build-release-artifacts.bash`, extracting both the versioned native archive and the stable latest-download archive, running `agentbox version`, and using the extracted binary to run `agentbox init --batch` successfully against a temp repo with local image refs.
+- [x] The Docker CLI image path remains available only as a clearly deprecated fallback during the transition.
+  Verified in `README.md` and `docs/troubleshooting.md`; `images/cli/Dockerfile` was intentionally left unchanged.
+- [x] Homebrew and installer-script work are called out as fast-follow, not hidden inside m13 scope.
+  Verified in the task plan and the updated Go-first install framing.
 
 ### Learnings
 
-Pending execution.
+- `go version -m` is a useful release-packaging check for cross-compiled Go binaries because it validates embedded build metadata without needing to execute every target binary on the current host.
+- Draft-first tag workflows are safer than `release.published` for binary assets because they keep the tag as the build source of truth while avoiding public releases with missing or partial artifacts.
+- Stable latest-download asset names also need stable archive contents. Copying a versioned tarball to an unversioned filename is not enough if the unpacked directory still changes every release.
 
 ### Follow-up Items
 
+- Exercise `.github/workflows/release-go-binaries.yml` from the first real version tag and capture any workflow-specific fixes that only show up in GitHub Actions.
 - Plan a follow-up task to remove the old Bash CLI distribution path and decide whether the deprecated Docker CLI image should switch to the Go binary first or be removed entirely.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,7 +97,8 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 ## m13: Go CLI rewrite (planned)
 
 - Rewrite agentbox CLI in Go using Cobra
-- Single static binary distribution (replace Docker CLI image)
+- GitHub Releases binaries become the primary install path
+- Docker CLI image remains temporarily as a deprecated fallback until old CLI removal follow-up work lands
 - Native YAML handling (drop yq dependency)
 - Cross-compile for macOS (arm64, amd64) and Linux
 - Port all existing commands with improved testing

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,12 +20,22 @@ This affects any `docker pull` or `docker login` command.
 
 The `osxkeychain` helper is included with Docker CLI packages installed via Homebrew and stores credentials in macOS Keychain.
 
-## Running agentbox CLI via Docker image
+## Deprecated Docker-image fallback for agentbox
 
-When running `agentbox` as a Docker container instead of a local install, there are a few limitations to be aware of.
+The primary supported install path is the local Go binary from GitHub Releases. The Docker CLI image remains available
+as a deprecated fallback during the transition, and it has a few limitations.
 
-**Editor integration is limited.** Commands like `agentbox edit policy` will use `vi` inside the container image rather than your host editor. Set the local install if you want `$EDITOR` to work normally.
+**Editor integration is limited.** Commands like `agentbox edit policy` will use `vi` inside the container image rather than your host editor. Use the local binary install if you want `$EDITOR` to work normally.
 
 **Host environment variables are not available.** Docker Compose runs inside the CLI container, so it won't see your host environment variables unless you forward them explicitly with `-e`. `HOME` is already forwarded in the recommended alias.
 
 **File permissions.** The CLI image runs as root to avoid permission issues with the Docker socket. On Colima, file ownership is mapped automatically. On Linux, add `--user $(id -u):$(id -g)` to the `docker run` command to match your host user.
+
+## agentbox not found after binary install
+
+If you installed the Go binary successfully but your shell still cannot find `agentbox`, check where you installed it
+and whether that directory is on your `PATH`.
+
+- `sudo install ... /usr/local/bin/agentbox` works on most macOS and Linux setups because `/usr/local/bin` is already on `PATH`
+- If you install somewhere else, add that directory to your shell profile and start a new shell
+- If your shell still resolves an older command path, run `hash -r` before trying again

--- a/images/agents/codex/Dockerfile
+++ b/images/agents/codex/Dockerfile
@@ -4,15 +4,19 @@
 ARG BASE_IMAGE=agent-sandbox-base:local
 FROM ${BASE_IMAGE}
 
-# Optional extra packages
+# Install bubblewrap so Codex's startup probe finds /usr/bin/bwrap.
+# Optional extra packages can be layered on top via EXTRA_PACKAGES.
 ARG EXTRA_PACKAGES=""
 USER root
-RUN if [ -n "$EXTRA_PACKAGES" ]; then \
+RUN set -e && \
+    PACKAGES="bubblewrap" && \
+    if [ -n "$EXTRA_PACKAGES" ]; then \
       printf '%s' "$EXTRA_PACKAGES" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9.+ :-]*$' \
         || { echo "ERROR: EXTRA_PACKAGES contains invalid characters: $EXTRA_PACKAGES" >&2; exit 1; }; \
-      apt-get update && apt-get install -y --no-install-recommends $EXTRA_PACKAGES \
-      && apt-get clean && rm -rf /var/lib/apt/lists/*; \
-    fi
+      PACKAGES="$PACKAGES $EXTRA_PACKAGES"; \
+    fi && \
+    apt-get update && apt-get install -y --no-install-recommends $PACKAGES \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Bake in the system codex config (can be overridden at user or project level)
 RUN mkdir -p /etc/codex

--- a/internal/scaffold/compose.go
+++ b/internal/scaffold/compose.go
@@ -326,7 +326,7 @@ func ensureCLIAgentPolicyRuntimeConfig(repoRoot string, agent string) error {
 }
 
 func writeComposeDocument(path string, header string, doc composeDocument) error {
-	body, err := yaml.Marshal(doc)
+	body, err := marshalYAML(doc)
 	if err != nil {
 		return err
 	}

--- a/internal/scaffold/compose_image_test.go
+++ b/internal/scaffold/compose_image_test.go
@@ -25,7 +25,7 @@ func TestSetComposeServiceImagePreservesHeaderAndUpdatesService(t *testing.T) {
 	if !strings.HasPrefix(string(data), "# Managed by agentbox\n\n") {
 		t.Fatalf("expected header to be preserved, got %q", string(data))
 	}
-	if !strings.Contains(string(data), "ghcr.io/example/proxy@sha256:abc123") {
+	if !strings.Contains(string(data), "services:\n  proxy:\n    image: ghcr.io/example/proxy@sha256:abc123\n") {
 		t.Fatalf("expected updated image, got %q", string(data))
 	}
 }
@@ -61,7 +61,7 @@ func TestSetComposeServiceImagePreservesBlankNamedVolumeEntries(t *testing.T) {
 	if strings.Contains(body, ": null") {
 		t.Fatalf("expected blank named volume entries, got %q", body)
 	}
-	if !strings.Contains(body, "volumes:\n    claude-state:\n    claude-history:\n") {
+	if !strings.Contains(body, "volumes:\n  claude-state:\n  claude-history:\n") {
 		t.Fatalf("expected named volumes to stay blank and ordered, got %q", body)
 	}
 }

--- a/internal/scaffold/policy.go
+++ b/internal/scaffold/policy.go
@@ -25,7 +25,7 @@ func WritePolicyFile(path string, services ...string) error {
 	}
 	doc.Services = compactStrings(services)
 
-	body, err := yaml.Marshal(doc)
+	body, err := marshalYAML(doc)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func writeDevcontainerPolicyFile(path string, ide string) error {
 		doc.Services = []string{ide}
 	}
 
-	body, err := yaml.Marshal(doc)
+	body, err := marshalYAML(doc)
 	if err != nil {
 		return err
 	}

--- a/internal/scaffold/policy_test.go
+++ b/internal/scaffold/policy_test.go
@@ -18,6 +18,9 @@ func TestWritePolicyFileCompactsServicesAndPreservesHeader(t *testing.T) {
 	if !strings.HasPrefix(data, "# Agent sandbox network policy") {
 		t.Fatalf("expected template header to be preserved, got %q", data)
 	}
+	if !strings.Contains(data, "services:\n  - vscode\n  - github\n") {
+		t.Fatalf("expected two-space YAML indentation, got %q", data)
+	}
 
 	policy := readPolicy(t, path)
 	want := []string{"vscode", "github"}

--- a/internal/scaffold/templates_test.go
+++ b/internal/scaffold/templates_test.go
@@ -1,6 +1,11 @@
 package scaffold
 
 import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	gruntime "runtime"
 	"strings"
 	"testing"
 )
@@ -23,4 +28,75 @@ func TestReadTemplateLoadsNestedAgentTemplate(t *testing.T) {
 	if !strings.Contains(string(data), "agent-sandbox-opencode") {
 		t.Fatalf("unexpected nested template contents: %q", string(data))
 	}
+}
+
+func TestYAMLTemplatesUseTwoSpaceIndentation(t *testing.T) {
+	checkYAMLTemplateIndentation(t, "embedded", TemplatesFS())
+	checkYAMLTemplateIndentation(t, "bash-cli", os.DirFS(sourceTemplateDir(t)))
+}
+
+func checkYAMLTemplateIndentation(t *testing.T, label string, templates fs.FS) {
+	t.Helper()
+
+	err := fs.WalkDir(templates, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".yml" && ext != ".yaml" {
+			return nil
+		}
+
+		data, err := fs.ReadFile(templates, path)
+		if err != nil {
+			return err
+		}
+
+		for lineNumber, line := range strings.Split(string(data), "\n") {
+			whitespaceWidth := leadingIndentWidth(line)
+			if whitespaceWidth == 0 {
+				continue
+			}
+
+			prefix := line[:whitespaceWidth]
+			if strings.Contains(prefix, "\t") {
+				return fmt.Errorf("%s:%d uses tab indentation", path, lineNumber+1)
+			}
+			if strings.Count(prefix, " ")%2 != 0 {
+				return fmt.Errorf("%s:%d uses %d leading spaces", path, lineNumber+1, strings.Count(prefix, " "))
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%s YAML template indentation check failed: %v", label, err)
+	}
+}
+
+func leadingIndentWidth(line string) int {
+	width := 0
+	for width < len(line) {
+		switch line[width] {
+		case ' ', '\t':
+			width++
+		default:
+			return width
+		}
+	}
+
+	return width
+}
+
+func sourceTemplateDir(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := gruntime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "cli", "templates"))
 }

--- a/internal/scaffold/yaml.go
+++ b/internal/scaffold/yaml.go
@@ -1,0 +1,23 @@
+package scaffold
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+func marshalYAML(document any) ([]byte, error) {
+	var body bytes.Buffer
+
+	encoder := yaml.NewEncoder(&body)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(document); err != nil {
+		_ = encoder.Close()
+		return nil, err
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+
+	return body.Bytes(), nil
+}

--- a/scripts/build-release-artifacts.bash
+++ b/scripts/build-release-artifacts.bash
@@ -1,0 +1,189 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+usage() {
+	cat <<'EOF'
+Usage: scripts/build-release-artifacts.bash --version <vX.Y.Z> [--out-dir <dir>]
+
+Builds release archives for:
+  - darwin/amd64
+  - darwin/arm64
+  - linux/amd64
+  - linux/arm64
+
+Each archive contains:
+  - agentbox
+  - LICENSE
+
+The script writes:
+  - versioned archives and `agentbox_<version>_checksums.txt`
+  - stable latest-download archives and `agentbox_checksums.txt`
+EOF
+}
+
+VERSION=""
+OUT_DIR="$REPO_ROOT/dist/release"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--version)
+		VERSION="${2:-}"
+		shift 2
+		;;
+	--out-dir)
+		OUT_DIR="${2:-}"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'unknown argument: %s\n' "$1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+done
+
+if [ -z "$VERSION" ]; then
+	printf '%s\n' '--version is required' >&2
+	usage >&2
+	exit 1
+fi
+
+case "$VERSION" in
+v*) ;;
+*)
+	printf 'version must start with v, got %s\n' "$VERSION" >&2
+	exit 1
+	;;
+esac
+
+if ! command -v go >/dev/null 2>&1; then
+	printf '%s\n' 'go is required' >&2
+	exit 1
+fi
+
+if ! command -v tar >/dev/null 2>&1; then
+	printf '%s\n' 'tar is required' >&2
+	exit 1
+fi
+
+sha256_line() {
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1"
+		return
+	fi
+
+	sha256sum "$1"
+}
+
+native_smoke_test() {
+	local binary="$1"
+	local expected_version="$2"
+	local output
+
+	output="$("$binary" version)"
+	printf '%s\n' "$output" | grep -F "$expected_version" >/dev/null
+	printf '%s\n' "$output" | grep -F 'source: ldflags' >/dev/null
+}
+
+metadata_smoke_test() {
+	local binary="$1"
+	go version -m "$binary" >/dev/null
+}
+
+VERSION_NUMBER="${VERSION#v}"
+BUILD_COMMIT="${BUILD_COMMIT:-$(git -C "$REPO_ROOT" rev-parse HEAD)}"
+BUILD_TIME="${BUILD_TIME:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
+if [ -n "${BUILD_DIRTY:-}" ]; then
+	DIRTY_VALUE="$BUILD_DIRTY"
+elif [ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no)" ]; then
+	DIRTY_VALUE=true
+else
+	DIRTY_VALUE=false
+fi
+
+HOST_GOOS="$(go env GOOS)"
+HOST_GOARCH="$(go env GOARCH)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$OUT_DIR"
+rm -f \
+	"$OUT_DIR"/agentbox_"$VERSION_NUMBER"_*.tar.gz \
+	"$OUT_DIR"/agentbox_"$VERSION_NUMBER"_checksums.txt \
+	"$OUT_DIR"/agentbox_darwin_amd64.tar.gz \
+	"$OUT_DIR"/agentbox_darwin_arm64.tar.gz \
+	"$OUT_DIR"/agentbox_linux_amd64.tar.gz \
+	"$OUT_DIR"/agentbox_linux_arm64.tar.gz \
+	"$OUT_DIR"/agentbox_checksums.txt
+
+LD_FLAGS="-X github.com/mattolson/agent-sandbox/internal/version.BuildVersion=$VERSION"
+LD_FLAGS="$LD_FLAGS -X github.com/mattolson/agent-sandbox/internal/version.BuildCommit=$BUILD_COMMIT"
+LD_FLAGS="$LD_FLAGS -X github.com/mattolson/agent-sandbox/internal/version.BuildTime=$BUILD_TIME"
+LD_FLAGS="$LD_FLAGS -X github.com/mattolson/agent-sandbox/internal/version.BuildDirty=$DIRTY_VALUE"
+
+TARGETS=(
+	"darwin amd64"
+	"darwin arm64"
+	"linux amd64"
+	"linux arm64"
+)
+
+for target in "${TARGETS[@]}"; do
+	goos="${target% *}"
+	goarch="${target#* }"
+	versioned_archive_stem="agentbox_${VERSION_NUMBER}_${goos}_${goarch}"
+	latest_archive_stem="agentbox_${goos}_${goarch}"
+	versioned_stage_dir="$TMP_DIR/$versioned_archive_stem"
+	latest_stage_dir="$TMP_DIR/$latest_archive_stem"
+	versioned_archive_path="$OUT_DIR/$versioned_archive_stem.tar.gz"
+	latest_archive_path="$OUT_DIR/$latest_archive_stem.tar.gz"
+	built_binary="$TMP_DIR/agentbox-${goos}-${goarch}"
+
+	mkdir -p "$versioned_stage_dir" "$latest_stage_dir"
+	CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+		go build -trimpath -ldflags "$LD_FLAGS" -o "$built_binary" ./cmd/agentbox
+	cp "$built_binary" "$versioned_stage_dir/agentbox"
+	cp "$built_binary" "$latest_stage_dir/agentbox"
+	cp "$REPO_ROOT/LICENSE" "$versioned_stage_dir/LICENSE"
+	cp "$REPO_ROOT/LICENSE" "$latest_stage_dir/LICENSE"
+
+	metadata_smoke_test "$built_binary"
+	if [ "$goos" = "$HOST_GOOS" ] && [ "$goarch" = "$HOST_GOARCH" ]; then
+		native_smoke_test "$built_binary" "$VERSION"
+	fi
+
+	tar -C "$TMP_DIR" -czf "$versioned_archive_path" "$versioned_archive_stem"
+	tar -C "$TMP_DIR" -czf "$latest_archive_path" "$latest_archive_stem"
+done
+
+versioned_checksum_file="$OUT_DIR/agentbox_${VERSION_NUMBER}_checksums.txt"
+: >"$versioned_checksum_file"
+for archive in "$OUT_DIR"/agentbox_"$VERSION_NUMBER"_*.tar.gz; do
+	sha256_line "$archive" >>"$versioned_checksum_file"
+done
+
+latest_checksum_file="$OUT_DIR/agentbox_checksums.txt"
+(
+	cd "$OUT_DIR"
+	: >"$(basename "$versioned_checksum_file")"
+	for archive in agentbox_"$VERSION_NUMBER"_*.tar.gz; do
+		sha256_line "$archive" >>"$(basename "$versioned_checksum_file")"
+	done
+
+	: >"$(basename "$latest_checksum_file")"
+	for archive in \
+		agentbox_darwin_amd64.tar.gz \
+		agentbox_darwin_arm64.tar.gz \
+		agentbox_linux_amd64.tar.gz \
+		agentbox_linux_arm64.tar.gz; do
+		sha256_line "$archive" >>"$(basename "$latest_checksum_file")"
+	done
+)
+printf 'Built release artifacts in %s\n' "$OUT_DIR"

--- a/scripts/build-release-artifacts.bash
+++ b/scripts/build-release-artifacts.bash
@@ -164,11 +164,6 @@ for target in "${TARGETS[@]}"; do
 done
 
 versioned_checksum_file="$OUT_DIR/agentbox_${VERSION_NUMBER}_checksums.txt"
-: >"$versioned_checksum_file"
-for archive in "$OUT_DIR"/agentbox_"$VERSION_NUMBER"_*.tar.gz; do
-	sha256_line "$archive" >>"$versioned_checksum_file"
-done
-
 latest_checksum_file="$OUT_DIR/agentbox_checksums.txt"
 (
 	cd "$OUT_DIR"


### PR DESCRIPTION
## Summary

- Add a draft-first Go binary release workflow for `v*` tags. The workflow runs Go tests and the Bash-vs-Go parity suite, builds release archives, uploads workflow artifacts, and creates or updates a draft GitHub Release.
- Add `scripts/build-release-artifacts.bash` to build `agentbox` for macOS and Linux on `amd64` and `arm64`, stamp release metadata via `ldflags`, include `LICENSE`, and generate checksum manifests.
- Publish both versioned assets, such as `agentbox_0.8.0_linux_arm64.tar.gz`, and stable latest-download assets, such as `agentbox_linux_arm64.tar.gz`, so users can use GitHub's `releases/latest/download/...` shortcut.
- Update README, CLI docs, troubleshooting, changelog, roadmap, and m13.6 planning artifacts for the Go binary release path. The main README now presents a single first-time install path.
- Normalize Go-generated YAML output to two-space indentation and add regressions for generated YAML plus template indentation.
- Add `bubblewrap` to the Codex image so Codex's startup probe finds `/usr/bin/bwrap`, while keeping isolation delegated to the container, proxy, and firewall.

## Testing

- `go test ./...`
- `./scripts/parity.bash`
- `bash -n /workspace/scripts/build-release-artifacts.bash`
- `BUILD_DIRTY=false ./scripts/build-release-artifacts.bash --version v0.8.0 --out-dir /tmp/agentbox-release-test`
- Extracted the native release archive and ran `agentbox version`
- Extracted the stable latest-download archive `agentbox_linux_arm64.tar.gz` and ran `agentbox version`
- Verified a release-built binary can run `agentbox init --batch` against a temp repo using local image refs

## Notes

- The new release workflow creates or updates a draft release. Publishing remains a manual step after assets and release notes are reviewed.
- The workflow has not yet been exercised from a real version tag in GitHub Actions.
- The old Docker CLI image remains available as a fallback and is intentionally left unchanged in this branch. Removing the old Bash CLI path is deferred to follow-up work.