### PR TITLE
m15: Github REST-only CLI

### DIFF
--- a/docs/plan/milestones/m13-go-cli-rewrite/milestone.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/milestone.md
@@ -19,7 +19,7 @@ legacy Bash CLI, parity harness, and Docker CLI image distribution were removed 
 - Documentation and release workflow updates that make the Go binary the primary installation path
 
 **Excluded:**
-- New CLI features from later milestones (`m14` through `m17`)
+- New CLI features from later milestones (`m14` through `m18`)
 - Changes to the layered runtime ownership model or proxy policy format
 - Windows support
 - Replacing the proxy-side `render-policy` helper with a separate host-side policy merge implementation
@@ -74,11 +74,11 @@ The Go rewrite should live beside the Bash CLI until the final cutover. `cli/` r
 
 ## Future TUI Compatibility
 
-`m13` should future-proof the CLI for `m16`, but it should not choose the `m16` UI architecture prematurely.
+`m13` should future-proof the CLI for `m17`, but it should not choose the `m17` UI architecture prematurely.
 
 - Cobra helps as a command entrypoint for future interactive subcommands, but it is not itself a TUI framework.
 - The Go rewrite should keep Cobra handlers thin and move runtime, policy, logging, and unblock logic into reusable internal packages that can back both standard CLI commands and a future TUI.
-- `m16` should choose its TUI framework independently during milestone planning once the monitoring workflow is better defined.
+- `m17` should choose its TUI framework independently during milestone planning once the monitoring workflow is better defined.
 - `Bubble Tea` is the most likely default choice for a future full-screen TUI, but that remains a likely direction rather than an `m13` commitment.
 
 ## Tasks
@@ -266,4 +266,4 @@ Documented that the Go rewrite will live under `cmd/`, `internal/`, `testdata/`,
 
 ### 2026-03-28: Added future TUI note
 
-Documented that m13 should keep core logic reusable for a future m16 interactive TUI, while deferring framework selection to m16 planning with Bubble Tea noted as the likely default.
+Documented that m13 should keep core logic reusable for a future m17 interactive TUI, while deferring framework selection to m17 planning with Bubble Tea noted as the likely default.

--- a/docs/plan/milestones/m15-github-rest-wrapper/milestone.md
+++ b/docs/plan/milestones/m15-github-rest-wrapper/milestone.md
@@ -1,8 +1,8 @@
 # Milestone: m15 - GitHub REST Wrapper
 
-Provide an officially supported GitHub wrapper built on Oktokit that uses REST-only endpoints so repo identity stays
-visible in request URLs and can be constrained by `m14` policies. The goal is not to replace stock `gh` wholesale; it
-is to provide a practical, repo-scoped GitHub tool surface that works with the fine-grained proxy model.
+Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
+URLs and can be constrained by `m14` policies. The goal is not to replace stock `gh` wholesale; it is to provide a
+practical, repo-scoped GitHub tool surface that works with the fine-grained proxy model.
 
 ## Problem
 
@@ -11,9 +11,9 @@ operations use GraphQL, where repo identity lives in the request body rather tha
 matched URL as a trusted endpoint and does not inspect request bodies. That makes broad `gh` support a poor match for
 repo-scoped URL policies.
 
-GitHub's REST API covers a large set of repo-centric workflows with repo identity encoded in the URL path. A wrapper on
-Oktokit can use that property directly instead of trying to coerce stock `gh` into a policy model it was not designed
-for.
+GitHub's REST API covers a large set of repo-centric workflows with repo identity encoded in the URL path. A thin
+wrapper on a REST-focused client library can use that property directly instead of trying to coerce stock `gh` into a
+policy model it was not designed for.
 
 ## Goals
 
@@ -36,7 +36,7 @@ for.
 
 ### Shape of the wrapper
 
-The wrapper should stay thin. The likely form is a small CLI on top of Oktokit REST calls that exposes a curated set of
+The wrapper should stay thin. The likely form is a small CLI on top of GitHub REST calls that exposes a curated set of
 repo-scoped commands such as repository view, issue list/create, pull-request list/view/create/merge where REST
 coverage is sufficient, release view, and workflow dispatch.
 
@@ -46,6 +46,21 @@ The wrapper should not try to perfectly mimic `gh` UX. It should optimize for:
 - repo scoping
 - policy compatibility
 - predictable mapping from command to REST endpoint family
+
+### Client library and language
+
+Go is now the leading implementation candidate because it would produce a standalone binary and fit the repo's existing
+Go-first CLI direction. The leading Go option is `google/go-github`.
+
+Node plus Octokit remains a viable fallback if implementation planning shows materially better REST coverage or lower
+integration cost for the initial supported command set.
+
+The selection criteria should be:
+
+- REST endpoint coverage for the supported workflows
+- ability to ship a standalone binary versus requiring a runtime
+- fit with the existing Go-based `agentbox` toolchain and release process
+- ease of keeping repo identity explicit in URL-based requests
 
 ### Repo scoping
 
@@ -65,9 +80,23 @@ flows that are already available in the environment. Later milestones can improv
 
 ### Distribution
 
-Because Oktokit is a JavaScript client, the wrapper will likely be Node-based unless implementation planning turns up a
-stronger alternative. Milestone planning should decide whether it belongs in the base image, a specific agent image, or
-as an optional tool installation path.
+If the wrapper is implemented in Go, it can ship as a standalone binary. If implementation planning chooses Node plus
+Octokit instead, then the runtime footprint and image/distribution story need to be justified explicitly.
+
+Milestone planning should decide whether the wrapper belongs in the base image, a specific agent image, or as an
+optional tool installation path.
+
+### Project boundary
+
+This milestone may later become its own open-source project. The current rationale is that there does not appear to be
+an obvious standalone-binary equivalent to `gh` that intentionally stays on REST-only endpoints for use in constrained
+environments with network proxy inspection.
+
+That project-boundary decision is deferred for now. `m15` should proceed in a way that keeps extraction feasible later:
+
+- keep the wrapper surface narrow and well documented
+- avoid coupling the command surface too tightly to Agent Sandbox internals
+- prefer packaging and tests that would still make sense if the wrapper moved into its own repository later
 
 ## Tasks
 
@@ -75,7 +104,9 @@ To be broken down when work begins. Rough outline:
 
 - Select the supported command subset based on real repo-scoped workflows that map cleanly to REST
 - Design the wrapper CLI surface and repo-scoping model
-- Implement the wrapper on Oktokit REST calls only
+- Choose the implementation language and client library (`go-github` is the leading candidate; Octokit remains the main
+  alternative)
+- Implement the wrapper on REST calls only
 - Add policy examples showing single-repo access under `m14`
 - Document unsupported workflows that still require stock `gh` or broader trust
 - Test the wrapper against representative GitHub workflows and failure modes
@@ -85,7 +116,11 @@ To be broken down when work begins. Rough outline:
 - Which top 10 repo-centric workflows are important enough to support in the first cut?
 - Should the wrapper require explicit `--repo`, or is deriving repo from the current checkout acceptable if it remains
   single-repo scoped?
+- Is Go plus `google/go-github` sufficient for the supported workflow set, or do any required workflows push the
+  milestone toward Node plus Octokit?
 - Should the wrapper live in the base image, selected agent images, or be user-installed?
+- Should the wrapper remain inside Agent Sandbox long term, or does the standalone binary use case justify spinning it
+  out after the first useful version?
 - Which workflows that look repo-scoped on the surface still fan out into broader trust assumptions in practice?
 - Is the wrapper's output primarily human-oriented, script-oriented, or both?
 

--- a/docs/plan/milestones/m15-github-rest-wrapper/milestone.md
+++ b/docs/plan/milestones/m15-github-rest-wrapper/milestone.md
@@ -1,0 +1,98 @@
+# Milestone: m15 - GitHub REST Wrapper
+
+Provide an officially supported GitHub wrapper built on Oktokit that uses REST-only endpoints so repo identity stays
+visible in request URLs and can be constrained by `m14` policies. The goal is not to replace stock `gh` wholesale; it
+is to provide a practical, repo-scoped GitHub tool surface that works with the fine-grained proxy model.
+
+## Problem
+
+Stock `gh` is not a good fit for `m14`-style single-repo policy enforcement in the general case because many common
+operations use GraphQL, where repo identity lives in the request body rather than the URL. `m14` intentionally treats a
+matched URL as a trusted endpoint and does not inspect request bodies. That makes broad `gh` support a poor match for
+repo-scoped URL policies.
+
+GitHub's REST API covers a large set of repo-centric workflows with repo identity encoded in the URL path. A wrapper on
+Oktokit can use that property directly instead of trying to coerce stock `gh` into a policy model it was not designed
+for.
+
+## Goals
+
+- Support a curated set of high-value, repo-scoped GitHub workflows using REST-only endpoints
+- Keep repo identity explicit in request URLs so a single-repo allowlist is practical under `m14`
+- Provide a stable, documented wrapper surface instead of asking users to memorize raw REST routes
+- Make the supported subset explicit and document what remains unsupported because it depends on GraphQL or broader
+  trust assumptions
+- Start with existing/manual auth flows and leave tighter integration with later credential milestones as follow-up work
+
+## Out of Scope
+
+- Full parity with stock `gh`
+- GraphQL-backed GitHub operations
+- Header or request-body inspection beyond what `m14` already supports
+- Replacing git itself for clone, fetch, checkout, push, or merge mechanics
+- Solving every GitHub auth flow in this milestone
+
+## Design
+
+### Shape of the wrapper
+
+The wrapper should stay thin. The likely form is a small CLI on top of Oktokit REST calls that exposes a curated set of
+repo-scoped commands such as repository view, issue list/create, pull-request list/view/create/merge where REST
+coverage is sufficient, release view, and workflow dispatch.
+
+The wrapper should not try to perfectly mimic `gh` UX. It should optimize for:
+
+- explicitness
+- repo scoping
+- policy compatibility
+- predictable mapping from command to REST endpoint family
+
+### Repo scoping
+
+Repo scope should be explicit in the command surface, either as a required `--repo owner/name` style flag or a clearly
+defined current-repo default that never broadens beyond one repository without an explicit user action.
+
+The important architectural point is that the repo identity must remain visible in the final REST path so `m14` can
+constrain access via URL-based rules.
+
+### Auth
+
+This milestone does not need to invent a new credential path. It can start by working with the existing/manual token
+flows that are already available in the environment. Later milestones can improve the auth story:
+
+- `m16` for proxy-side secret injection
+- `m18` for residual helper-based flows
+
+### Distribution
+
+Because Oktokit is a JavaScript client, the wrapper will likely be Node-based unless implementation planning turns up a
+stronger alternative. Milestone planning should decide whether it belongs in the base image, a specific agent image, or
+as an optional tool installation path.
+
+## Tasks
+
+To be broken down when work begins. Rough outline:
+
+- Select the supported command subset based on real repo-scoped workflows that map cleanly to REST
+- Design the wrapper CLI surface and repo-scoping model
+- Implement the wrapper on Oktokit REST calls only
+- Add policy examples showing single-repo access under `m14`
+- Document unsupported workflows that still require stock `gh` or broader trust
+- Test the wrapper against representative GitHub workflows and failure modes
+
+## Open Questions
+
+- Which top 10 repo-centric workflows are important enough to support in the first cut?
+- Should the wrapper require explicit `--repo`, or is deriving repo from the current checkout acceptable if it remains
+  single-repo scoped?
+- Should the wrapper live in the base image, selected agent images, or be user-installed?
+- Which workflows that look repo-scoped on the surface still fan out into broader trust assumptions in practice?
+- Is the wrapper's output primarily human-oriented, script-oriented, or both?
+
+## Definition of Done
+
+- At least one meaningful repo-scoped GitHub workflow set can be executed through the wrapper using REST-only endpoints
+- The supported wrapper commands keep repo identity visible in URL paths and are compatible with `m14` policy matching
+- The supported subset and unsupported GraphQL-dependent workflows are documented clearly
+- Policy examples exist for constraining the wrapper to a single GitHub repository
+- The auth story for the wrapper is documented, even if richer secret handling is deferred to later milestones

--- a/docs/plan/milestones/m18-host-credential-service/milestone.md
+++ b/docs/plan/milestones/m18-host-credential-service/milestone.md
@@ -1,10 +1,10 @@
-# m17: Host Credential Service
+# m18: Host Credential Service
 
-Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m15-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
+Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m16-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
 
 ## Problem
 
-`m15-proxy-secret-injection` should be the primary path for HTTP-native credentials, especially git over HTTPS and other request-decorated auth patterns. Some flows still do not fit that model:
+`m16-proxy-secret-injection` should be the primary path for HTTP-native credentials, especially git over HTTPS and other request-decorated auth patterns. Some flows still do not fit that model:
 
 - Browser-driven or device-code login flows where the client expects local auth state
 - Tools that insist on a credential-helper protocol instead of pure outbound request transformation
@@ -13,7 +13,7 @@ Run a narrower host-side credential service for auth flows that cannot be handle
 
 ## Goals
 
-- Secondary credential path for cases `m15` cannot cover
+- Secondary credential path for cases `m16` cannot cover
 - Credentials stored in the host's native credential store, never persisted on disk inside the container
 - Support credential-helper-shaped clients and similar local-delivery flows
 - Minimal configuration: the service starts when the sandbox starts and stops when it stops
@@ -51,12 +51,12 @@ Git's credential helper protocol is still the main reference protocol for this m
 - `store` - Save credentials after successful authentication
 - `erase` - Remove stored credentials
 
-The HTTP wrapper translates these into `POST /get`, `POST /store`, `POST /erase` with the key=value body. If a later client needs a different helper-facing protocol, add it only if `m15` cannot cover the use case.
+The HTTP wrapper translates these into `POST /get`, `POST /store`, `POST /erase` with the key=value body. If a later client needs a different helper-facing protocol, add it only if `m16` cannot cover the use case.
 
 ### Security considerations
 
 - The service should only accept connections from the container network, not the wider host network
-- Consider scoping credential lookups to domains or services not already handled by `m15`
+- Consider scoping credential lookups to domains or services not already handled by `m16`
 - The raw token transits the Docker bridge network in the HTTP response. This is the same trust boundary as the proxy CA cert distribution, which already happens over this path
 - Rate limiting or audit logging on the host service would help detect credential abuse
 
@@ -76,13 +76,13 @@ The service could run as:
 - A host-side process started by `agentbox exec` (more natural, direct access to host keychain)
 - Part of the proxy sidecar (reuses existing infrastructure, but mixes concerns)
 
-The `agentbox exec` approach is the most natural fit. The CLI already manages the compose lifecycle. It can start the credential service before `docker compose up` and stop it after `docker compose down`. This milestone should only be attempted after `m15` settles the primary proxy-based path, so the helper solves the residual set of unsupported flows instead of becoming a competing default.
+The `agentbox exec` approach is the most natural fit. The CLI already manages the compose lifecycle. It can start the credential service before `docker compose up` and stop it after `docker compose down`. This milestone should only be attempted after `m16` settles the primary proxy-based path, so the helper solves the residual set of unsupported flows instead of becoming a competing default.
 
 ## Tasks
 
 To be broken down when work begins. Rough outline:
 
-- Identify the residual auth flows that still cannot be handled by `m15`
+- Identify the residual auth flows that still cannot be handled by `m16`
 - Design and implement the HTTP credential protocol wrapper
 - Implement the host-side service (Go, to match the planned CLI language)
 - Implement the container-side shim (shell script using curl, or a small Go binary)
@@ -94,15 +94,15 @@ To be broken down when work begins. Rough outline:
 ## Open Questions
 
 - Should the service require an auth token of its own to prevent other containers on the same Docker network from using it?
-- Which real workflows remain after `m15` lands, and are they important enough to justify the helper complexity?
+- Which real workflows remain after `m16` lands, and are they important enough to justify the helper complexity?
 - Should credential scoping (allowlist-only domains) be enforced at the service level or left to the proxy?
 - Is HTTP over the Docker bridge acceptable, or should the service use a Unix socket mounted into the container?
 - Should the service support credential caching (short TTL) to reduce round-trips to the host keychain?
 
 ## Definition of Done
 
-- [ ] At least one important unsupported flow after `m15` can authenticate using the host credential service with no tokens on disk in the container
-- [ ] `m15` is documented as the primary credential path and this service is documented as the fallback path
+- [ ] At least one important unsupported flow after `m16` can authenticate using the host credential service with no tokens on disk in the container
+- [ ] `m16` is documented as the primary credential path and this service is documented as the fallback path
 - [ ] Works on macOS (Colima) out of the box
 - [ ] Documented for Windows and Linux desktop
 - [ ] Graceful fallback when the service is unavailable (clear error message, not silent failure)

--- a/docs/plan/milestones/m6-cli/milestone.md
+++ b/docs/plan/milestones/m6-cli/milestone.md
@@ -25,7 +25,7 @@ Give developers a single command-line tool that handles the full lifecycle of an
 **Excluded:**
 - Go rewrite (m13)
 - Fine-grained proxy rules (m14)
-- Interactive monitoring/unblocking (m16)
+- Interactive monitoring/unblocking (m17)
 
 ## Applicable Learnings
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -222,7 +222,26 @@ Extend proxy enforcement beyond domain-level rules to support path, method, and 
 
 **Dependencies:** m3 (proxy established)
 
-### m15-proxy-secret-injection
+### m15-github-rest-wrapper
+
+Provide an officially supported GitHub wrapper built on Oktokit that uses REST-only endpoints so repo identity stays
+visible in request URLs and can be constrained by `m14` policies.
+
+**Goals:**
+- Support a curated set of common, repo-scoped GitHub workflows using REST-only endpoints
+- Keep repo identity explicit in URL paths so single-repo allowlists are practical under `m14`
+- Prefer a thin wrapper over full parity with stock `gh`
+- Define and document the supported subset plus unsupported GraphQL- or body-dependent flows
+- Start with existing/manual auth flows and leave tighter credential-path integration to later milestones
+
+**Out of scope:**
+- Full parity with stock `gh`
+- GraphQL-backed GitHub operations
+- Re-implementing every GitHub workflow behind one generic wrapper surface
+
+**Dependencies:** m14 (fine-grained proxy and repo/path-aware policy matching)
+
+### m16-proxy-secret-injection
 
 Make the proxy the primary credential path for HTTP-native auth by keeping real secrets out of the agent container and injecting them into matched outbound requests.
 
@@ -241,7 +260,7 @@ Make the proxy the primary credential path for HTTP-native auth by keeping real 
 
 **Dependencies:** m14 (request-phase MITM matching), m3 (proxy foundation)
 
-### m16-cli-monitoring
+### m17-cli-monitoring
 
 CLI tools for monitoring proxy activity and managing policy interactively.
 
@@ -253,17 +272,17 @@ CLI tools for monitoring proxy activity and managing policy interactively.
 
 **Dependencies:** m13 (Go CLI), m14 (fine-grained proxy and hot reload)
 
-### m17-host-credential-service
+### m18-host-credential-service
 
 Add a narrower, secondary credential path for tools and auth flows that cannot be handled cleanly by proxy-side injection.
 
 **Goals:**
 - Host-side credential helper bridge for clients that must obtain a credential locally
-- Support non-HTTP or helper-protocol-shaped auth workflows that `m15` cannot cover
+- Support non-HTTP or helper-protocol-shaped auth workflows that `m16` cannot cover
 - Keep credentials off disk inside the container even when the client must receive them
 - Integrate the helper lifecycle with the Go CLI
 
-**Dependencies:** m13 (Go CLI manages service lifecycle), m15 (primary proxy-based credential path defined first)
+**Dependencies:** m13 (Go CLI manages service lifecycle), m16 (primary proxy-based credential path defined first)
 
 ## Decisions
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -224,13 +224,14 @@ Extend proxy enforcement beyond domain-level rules to support path, method, and 
 
 ### m15-github-rest-wrapper
 
-Provide an officially supported GitHub wrapper built on Oktokit that uses REST-only endpoints so repo identity stays
-visible in request URLs and can be constrained by `m14` policies.
+Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
+URLs and can be constrained by `m14` policies.
 
 **Goals:**
 - Support a curated set of common, repo-scoped GitHub workflows using REST-only endpoints
 - Keep repo identity explicit in URL paths so single-repo allowlists are practical under `m14`
 - Prefer a thin wrapper over full parity with stock `gh`
+- Prefer a standalone binary if practical; Go plus `google/go-github` is the leading candidate
 - Define and document the supported subset plus unsupported GraphQL- or body-dependent flows
 - Start with existing/manual auth flows and leave tighter credential-path integration to later milestones
 

--- a/docs/plan/research/alternatives.md
+++ b/docs/plan/research/alternatives.md
@@ -1222,7 +1222,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - The WireGuard plus shared-namespace design adds startup ordering and networking complexity without solving the separate IDE control plane that the repo itself documents
   - The packaged workflow is devcontainer- and Claude-shaped, not a neutral multi-agent control plane
 - Open questions:
-  - Could proxy-side secret substitution cover enough of `m17-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
+  - Could proxy-side secret substitution cover enough of `m18-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
   - Do we need transparent capture enough to justify the added WireGuard complexity, given the current explicit proxy plus firewall design already blocks direct egress?
   - Should any sandcat-inspired work land as devcontainer-only hardening rather than as part of the core backend contract?
 - Verdict: `useful supporting reference`
@@ -1314,7 +1314,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - Remote execution or gateway fleet support: no
 - Key strengths:
   - This is a genuine stronger-isolation reference, not just a container-plus-proxy variant
-  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m18-backend-interface`
+  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m19-backend-interface`
   - Network policy is materially richer than our current baseline: host allow-listing, path and method matching, request or response mutation, runtime allow-list edits, and offline mode
   - The VFS layer is more interesting than it first appears; it creates a host-side place to enforce or observe filesystem operations without bind-mounting the host repo directly into the guest
   - Lifecycle persistence and reconciliation are stronger than most research repos in this space
@@ -1335,7 +1335,7 @@ When reviewing an item, capture whether it implements any of these primitives:
 
 - Worth bringing into the vision:
   - a real microVM-backed stronger-isolation backend candidate
-  - host-side VFS and exec control-plane separation as input to `m18-backend-interface`
+  - host-side VFS and exec control-plane separation as input to `m19-backend-interface`
   - richer HTTP policy concepts for `m14`, especially method and path matching plus response shaping
   - lifecycle persistence and explicit garbage-collection or reconcile workflows for leaked sandbox resources
 - Probably not worth bringing in as-is:
@@ -1344,7 +1344,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - assuming a FUSE or VFS workspace model is the right default for local developer ergonomics before measuring it against a shared mount model
 - Research consequence:
   - Treat `matchlock` as a leading reference for the optional stronger-isolation backend and for backend-interface design, not as an argument to replace the current local default before we have comparative measurements
-  - It should directly inform `m18-backend-interface` and `m20-runtime-spikes-vm`
+  - It should directly inform `m19-backend-interface` and `m21-runtime-spikes-vm`
 
 ### strongdm/leash
 
@@ -1444,7 +1444,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - accepting materially different network semantics on macOS and Linux under one policy name without very clear degradation rules
 - Research consequence:
   - Treat `leash` as a leading reference for policy IR, rollout modes, and observability, not as proof that a container boundary alone is sufficient for the project's stronger-isolation backend
-  - It should inform `m17-capability-model` and `m18-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
+  - It should inform `m18-capability-model` and `m19-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
 
 ## Research backlog: commercial products
 
@@ -1644,15 +1644,15 @@ Deliverable:
 
 ## Proposed milestones
 
-### m17-capability-model
+### m18-capability-model
 
 Define the threat model, capability matrix, and backend scorecard.
 
-### m18-backend-interface
+### m19-backend-interface
 
 Define a backend-agnostic runner contract, event schema, and policy compiler boundary.
 
-### m19-runtime-spikes-lite
+### m20-runtime-spikes-lite
 
 Build and compare:
 
@@ -1660,7 +1660,7 @@ Build and compare:
 - OS-native backend
 - gVisor backend
 
-### m20-runtime-spikes-vm
+### m21-runtime-spikes-vm
 
 Build and compare:
 

--- a/docs/plan/research/alternatives.md
+++ b/docs/plan/research/alternatives.md
@@ -1314,7 +1314,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - Remote execution or gateway fleet support: no
 - Key strengths:
   - This is a genuine stronger-isolation reference, not just a container-plus-proxy variant
-  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m19-backend-interface`
+  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m20-backend-interface`
   - Network policy is materially richer than our current baseline: host allow-listing, path and method matching, request or response mutation, runtime allow-list edits, and offline mode
   - The VFS layer is more interesting than it first appears; it creates a host-side place to enforce or observe filesystem operations without bind-mounting the host repo directly into the guest
   - Lifecycle persistence and reconciliation are stronger than most research repos in this space
@@ -1335,7 +1335,7 @@ When reviewing an item, capture whether it implements any of these primitives:
 
 - Worth bringing into the vision:
   - a real microVM-backed stronger-isolation backend candidate
-  - host-side VFS and exec control-plane separation as input to `m19-backend-interface`
+  - host-side VFS and exec control-plane separation as input to `m20-backend-interface`
   - richer HTTP policy concepts for `m14`, especially method and path matching plus response shaping
   - lifecycle persistence and explicit garbage-collection or reconcile workflows for leaked sandbox resources
 - Probably not worth bringing in as-is:
@@ -1344,7 +1344,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - assuming a FUSE or VFS workspace model is the right default for local developer ergonomics before measuring it against a shared mount model
 - Research consequence:
   - Treat `matchlock` as a leading reference for the optional stronger-isolation backend and for backend-interface design, not as an argument to replace the current local default before we have comparative measurements
-  - It should directly inform `m19-backend-interface` and `m21-runtime-spikes-vm`
+  - It should directly inform `m20-backend-interface` and `m22-runtime-spikes-vm`
 
 ### strongdm/leash
 
@@ -1444,7 +1444,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - accepting materially different network semantics on macOS and Linux under one policy name without very clear degradation rules
 - Research consequence:
   - Treat `leash` as a leading reference for policy IR, rollout modes, and observability, not as proof that a container boundary alone is sufficient for the project's stronger-isolation backend
-  - It should inform `m18-capability-model` and `m19-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
+  - It should inform `m19-capability-model` and `m20-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
 
 ## Research backlog: commercial products
 
@@ -1644,15 +1644,15 @@ Deliverable:
 
 ## Proposed milestones
 
-### m18-capability-model
+### m19-capability-model
 
 Define the threat model, capability matrix, and backend scorecard.
 
-### m19-backend-interface
+### m20-backend-interface
 
 Define a backend-agnostic runner contract, event schema, and policy compiler boundary.
 
-### m20-runtime-spikes-lite
+### m21-runtime-spikes-lite
 
 Build and compare:
 
@@ -1660,21 +1660,21 @@ Build and compare:
 - OS-native backend
 - gVisor backend
 
-### m21-runtime-spikes-vm
+### m22-runtime-spikes-vm
 
 Build and compare:
 
 - Kata backend
 - One heavy-isolation backend such as Firecracker or full VM
 
-### m21-kubernetes-track
+### m23-kubernetes-track
 
 Only if earlier milestones justify it:
 
 - KubeVirt or Kata on Kubernetes
 - Cilium or similar for L7 policy and observability experiments
 
-### m22-decision-and-integration
+### m24-decision-and-integration
 
 Choose:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,7 +111,15 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Domain-only rules remain as fast-path (block at CONNECT)
 - SIGHUP-based hot reload for policy changes
 
-## m15: Proxy-side secret injection (planned)
+## m15: GitHub REST wrapper (planned)
+
+- Repo-scoped GitHub wrapper built on Oktokit using REST-only endpoints
+- Keep repo identity visible in request URLs so m14 policies can constrain access to one repo
+- Support a curated set of high-value GitHub workflows that fit REST plus URL-based policy matching
+- Define and document the supported subset and explicitly exclude GraphQL-dependent `gh` flows
+- Initial auth can reuse existing/manual token flows; tighter integration can come later
+
+## m16: Proxy-side secret injection (planned)
 
 - Make proxy injection the primary mechanism for HTTP-native credentials
 - Store raw secret values in a host-only source and mount them into the proxy only
@@ -119,14 +127,14 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - First rollout: git over HTTPS with repo-level scoping
 - Evaluate env-token clients such as `gh` where placeholder substitution is sufficient
 
-## m16: CLI monitoring and policy management (planned)
+## m17: CLI monitoring and policy management (planned)
 
 - Filtered log view for blocked requests
 - Interactive unblock workflow
 - Integration with hot reload for immediate policy updates
 - UI approach TBD (filtered stream, TUI, or hybrid)
 
-## m17: Host credential service (planned)
+## m18: Host credential service (planned)
 
 - Secondary credential path for flows that cannot be handled by proxy injection
 - Host-side service bridging container to native credential store or helper backend

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,9 +113,10 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 
 ## m15: GitHub REST wrapper (planned)
 
-- Repo-scoped GitHub wrapper built on Oktokit using REST-only endpoints
+- Repo-scoped GitHub wrapper using REST-only endpoints
 - Keep repo identity visible in request URLs so m14 policies can constrain access to one repo
 - Support a curated set of high-value GitHub workflows that fit REST plus URL-based policy matching
+- Prefer a standalone binary if practical; Go plus `google/go-github` is the leading candidate
 - Define and document the supported subset and explicitly exclude GraphQL-dependent `gh` flows
 - Initial auth can reuse existing/manual token flows; tighter integration can come later
 


### PR DESCRIPTION
Plan for new milestone (inserted as m15) - write a CLI for GitHub that only implements REST endpoints (no GraphQL) to make it compatible with the fine-grained network policy implemented in m14.
