### PR TITLE
Add python to local dev env and update python stack

### DIFF
--- a/.agent-sandbox/compose/agent.codex.yml
+++ b/.agent-sandbox/compose/agent.codex.yml
@@ -10,9 +10,7 @@ services:
   agent:
     image: ghcr.io/mattolson/agent-sandbox-codex@sha256:883ec21664c410b3943fdca146990e93e91426737cc83b8b6321cdee0ca454ae
     volumes:
-      # Persist Codex config and credentials
       - codex-state:/home/dev/.codex
-      # Persist shell history
       - codex-history:/commandhistory
 volumes:
   codex-state:

--- a/.agent-sandbox/compose/base.yml
+++ b/.agent-sandbox/compose/base.yml
@@ -7,14 +7,19 @@ services:
     image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:76de198087cefc7747b4171ff9d708dff8b5296242e15d9b7c9081b3b1d00577
     cap_drop:
       - ALL
-    environment:
-      - PROXY_MODE=enforce
     volumes:
       - proxy-state:/home/mitmproxy/.mitmproxy
       - proxy-ca:/ca-export
       - ../policy/user.policy.yaml:/etc/agent-sandbox/policy/user.policy.yaml:ro
+    environment:
+      - PROXY_MODE=enforce
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "8080"]
+      test:
+        - CMD
+        - nc
+        - -z
+        - localhost
+        - "8080"
       interval: 5s
       timeout: 3s
       retries: 3
@@ -25,19 +30,13 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      # iptables firewall rule management (init-firewall.sh)
       - NET_ADMIN
-      # Raw socket access for iptables (init-firewall.sh)
       - NET_RAW
-      # sudo to run init scripts as root (sudoers restricts to specific scripts)
       - SETUID
       - SETGID
     volumes:
-      # Project workspace
       - ../..:/workspace
-      # Read-only policy directory
       - ..:/workspace/.agent-sandbox:ro
-      # Proxy CA certificate (public cert only, no private key)
       - proxy-ca:/etc/mitmproxy:ro
     working_dir: /workspace
     stdin_open: true
@@ -47,7 +46,6 @@ services:
       - HTTP_PROXY=http://proxy:8080
       - HTTPS_PROXY=http://proxy:8080
       - NO_PROXY=localhost,127.0.0.1,proxy
-      # Disable HTTP/2 in Go clients (gh CLI) to avoid header validation issues through proxy
       - GODEBUG=http2client=0
 volumes:
   proxy-state:

--- a/.agent-sandbox/compose/user.override.yml
+++ b/.agent-sandbox/compose/user.override.yml
@@ -17,11 +17,9 @@ services:
       - go-build-cache:/home/dev/.cache/go-build
       - go-env:/home/dev/.config/go
       - pip-cache:/home/dev/.cache/pip
-      - pipx-home:/home/dev/.local/pipx
 volumes:
   go-tool-bin:
   go-mod-cache:
   go-build-cache:
   go-env:
   pip-cache:
-  pipx-home:

--- a/.agent-sandbox/compose/user.override.yml
+++ b/.agent-sandbox/compose/user.override.yml
@@ -12,12 +12,16 @@ services:
     volumes:
       - ${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro
       - ${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro
-      - go-bin:/home/dev/.local/bin
+      - go-tool-bin:/home/dev/go/bin
       - go-mod-cache:/home/dev/.cache/go-mod
       - go-build-cache:/home/dev/.cache/go-build
       - go-env:/home/dev/.config/go
+      - pip-cache:/home/dev/.cache/pip
+      - pipx-home:/home/dev/.local/pipx
 volumes:
-  go-bin:
+  go-tool-bin:
   go-mod-cache:
   go-build-cache:
   go-env:
+  pip-cache:
+  pipx-home:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 .env
 .idea
 .vscode
+.venv/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
 __pycache__/
 *.pyc
 .DS_Store

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,10 +12,12 @@ ENV GOCACHE=/home/dev/.cache/go-build
 
 # Setup python
 RUN /etc/agent-sandbox/stacks/python.sh
+RUN python3 -m venv /opt/proxy-python && \
+  /opt/proxy-python/bin/pip install --no-cache-dir mitmproxy pytest PyYAML
 ENV PIP_CACHE_DIR=/home/dev/.cache/pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIPX_HOME=/home/dev/.local/pipx
-ENV PIPX_BIN_DIR=/home/dev/.local/pipx/bin
-ENV PATH=/home/dev/.local/bin:/home/dev/.local/pipx/bin:/home/dev/go/bin:/usr/local/bin:/usr/local/go/bin:$PATH
+
+# Keep agent binaries ahead of the proxy test env and Go-installed tools.
+ENV PATH=/home/dev/.local/bin:/opt/proxy-python/bin:/usr/local/go/bin:$PATH:/home/dev/go/bin
 
 USER dev

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,12 +2,20 @@ ARG AGENT=opencode
 FROM agent-sandbox-${AGENT}:local
 
 USER root
-RUN /etc/agent-sandbox/stacks/go.sh 1.26.1
 
+# Setup go
+RUN /etc/agent-sandbox/stacks/go.sh 1.26.1
 ENV GOPATH=/home/dev/go
-ENV GOBIN=/home/dev/.local/bin
+ENV GOBIN=/home/dev/go/bin
 ENV GOMODCACHE=/home/dev/.cache/go-mod
 ENV GOCACHE=/home/dev/.cache/go-build
-ENV PATH=/usr/local/go/bin:/home/dev/.local/bin:/home/dev/go/bin:$PATH
+
+# Setup python
+RUN /etc/agent-sandbox/stacks/python.sh
+ENV PIP_CACHE_DIR=/home/dev/.cache/pip
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIPX_HOME=/home/dev/.local/pipx
+ENV PIPX_BIN_DIR=/home/dev/.local/pipx/bin
+ENV PATH=/home/dev/.local/bin:/home/dev/.local/pipx/bin:/home/dev/go/bin:/usr/local/bin:/usr/local/go/bin:$PATH
 
 USER dev

--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ services:
 
 domains:
   - registry.npmjs.org
-  - pypi.org
 ```
+
+Public package registries such as PyPI are intentionally not allowed by default. If you need them, add them explicitly
+to your user or per-agent policy. Prefer a private mirror or proxy when you have one.
 
 If you want to make customizations that apply to a single agent, you can edit the file `.agent-sandbox/policy/user.agent.<agent>.policy.yaml`. For example, to add a domain to the allowlist, but only when using Claude Code, add it to the file `user.agent.claude.policy.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Target platform: [Colima](https://github.com/abiosoft/colima) + [Docker Engine](
 
 | Agent | CLI | VS Code | JetBrains |
 |-------|-----|---------|-----------|
-| [Claude Code](https://code.claude.com/docs/en/overview) | :green_circle: | :green_circle: | :green_circle: |
-| [Codex](https://github.com/openai/codex) | :green_circle: | :large_blue_circle: | :large_blue_circle: |
-| [Gemini](https://github.com/google-gemini/gemini-cli) | :large_blue_circle: | :large_blue_circle: | :red_circle: |
-| [OpenCode](https://github.com/anomalyco/opencode) | :large_blue_circle: | :large_blue_circle: | :red_circle: |
-| [Pi](https://github.com/badlogic/pi-mono) | :large_blue_circle: | :red_circle: | :red_circle: |
-| [Factory](https://docs.factory.ai/cli) | :large_blue_circle: | :large_blue_circle: | :large_blue_circle: |
-| [Copilot](https://github.com/github/copilot-cli) | :large_blue_circle: | :large_blue_circle: | :red_circle: |
+| [Claude Code](https://code.claude.com/docs/en/overview) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Codex](https://github.com/openai/codex) | :white_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| [Gemini](https://github.com/google-gemini/gemini-cli) | :heavy_check_mark: | :heavy_check_mark: | :no_entry_sign: |
+| [OpenCode](https://github.com/anomalyco/opencode) | :heavy_check_mark: | :heavy_check_mark: | :no_entry_sign: |
+| [Pi](https://github.com/badlogic/pi-mono) | :heavy_check_mark: | :no_entry_sign: | :no_entry_sign: |
+| [Factory](https://docs.factory.ai/cli) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| [Copilot](https://github.com/github/copilot-cli) | :heavy_check_mark: | :heavy_check_mark: | :no_entry_sign: |
 
-* :green_circle: **Full Support** - stable, heavily used by maintainers
-* :large_blue_circle: **Preview** - tested during initial integration, but not heavily used by maintainers. Contributions, documentation, and bug reports welcome.
-* :red_circle: **Not Supported** - known blockers
+* :white_check_mark: **Full Support** - stable, heavily used by maintainers
+* :heavy_check_mark: **Preview** - tested during initial integration, but not heavily used by maintainers. Contributions, documentation, and bug reports welcome.
+* :no_entry_sign: **Not Supported** - known blockers
   * Copilot's IntelliJ plugin [cannot complete auth in a devcontainer](https://github.com/microsoft/copilot-intellij-feedback/issues/1375).
   * No official Google Gemini plugin available for JetBrains
   * No JetBrains extension available for OpenCode

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -25,7 +25,7 @@ agentbox up -d
 
 | Stack | Script | Version arg | Default | Guide |
 |-------|--------|-------------|---------|-------|
-| Python | `python.sh` | (ignored, uses apt) | System Python 3 | - |
+| Python | `python.sh` | (ignored, uses apt) | System Python 3, pipx, and native build toolchain | [Python stack](./python.md) |
 | Node.js | `node.sh` | Major version | 22 | - |
 | Go | `go.sh` | Full version | 1.26.1 | [Go stack](./go.md) |
 | Rust | `rust.sh` | Toolchain | stable | - |
@@ -34,6 +34,7 @@ Each script handles both amd64 and arm64 architectures.
 
 ## Stack-Specific Guides
 
+- [Python stack](./python.md) - Python build deps, user-local tool paths, and opt-in package registry policy
 - [Go stack](./go.md) - Go environment variables, persistent local dev mounts, and policy requirements
 
 ## Advanced

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -25,7 +25,7 @@ agentbox up -d
 
 | Stack | Script | Version arg | Default | Guide |
 |-------|--------|-------------|---------|-------|
-| Python | `python.sh` | (ignored, uses apt) | System Python 3, pipx, and native build toolchain | [Python stack](./python.md) |
+| Python | `python.sh` | (ignored, uses apt) | System Python 3, pip, venv, and native build toolchain | [Python stack](./python.md) |
 | Node.js | `node.sh` | Major version | 22 | - |
 | Go | `go.sh` | Full version | 1.26.1 | [Go stack](./go.md) |
 | Rust | `rust.sh` | Toolchain | stable | - |

--- a/docs/stacks/go.md
+++ b/docs/stacks/go.md
@@ -5,7 +5,7 @@ See [Language stacks](./README.md) for the shared stack workflow.
 The Go stack configures these paths for the `dev` user:
 
 - `GOPATH=$HOME/go`
-- `GOBIN=$HOME/.local/bin`
+- `GOBIN=$HOME/go/bin`
 - `GOMODCACHE=$HOME/.cache/go-mod`
 - `GOCACHE=$HOME/.cache/go-build`
 
@@ -16,20 +16,21 @@ bin dir, module cache, build cache, and Go env:
 services:
   agent:
     volumes:
-      - go-bin:/home/dev/.local/bin
+      - go-tool-bin:/home/dev/go/bin
       - go-mod-cache:/home/dev/.cache/go-mod
       - go-build-cache:/home/dev/.cache/go-build
       - go-env:/home/dev/.config/go
 
 volumes:
-  go-bin:
+  go-tool-bin:
   go-mod-cache:
   go-build-cache:
   go-env:
 ```
 
 Keep source code in `/workspace`, not under `GOPATH`. The stack also installs `build-essential` and `pkg-config` so
-CGO-backed packages can compile.
+CGO-backed packages can compile. `GOBIN` uses `$HOME/go/bin` rather than `~/.local/bin` so Go-installed tools do not
+mask agent binaries such as `codex`.
 
 For module downloads and `go install`, allow at least `proxy.golang.org` and `sum.golang.org` in your sandbox policy.
 If you run the installer script inside a running sandboxed container instead of during image build, you will also need

--- a/docs/stacks/python.md
+++ b/docs/stacks/python.md
@@ -10,7 +10,6 @@ The Python stack installs these system packages:
 - `python3-setuptools`
 - `python3-venv`
 - `python3-wheel`
-- `pipx`
 - `build-essential`
 - `pkg-config`
 - `libffi-dev`
@@ -18,41 +17,56 @@ The Python stack installs these system packages:
 
 It also configures these paths for the `dev` user:
 
-- `PATH=$HOME/.local/bin:$HOME/.local/pipx/bin:/usr/local/bin:$PATH`
+- `PATH=$HOME/.local/bin:/usr/local/bin:$PATH`
 - `PIP_CACHE_DIR=$HOME/.cache/pip`
-- `PIPX_HOME=$HOME/.local/pipx`
-- `PIPX_BIN_DIR=$HOME/.local/pipx/bin`
 
-Use the system interpreter only to create project environments. For normal work, create a project-local virtualenv in
-your checkout:
+Use the system interpreter only to create project environments. For normal work, pick one of these workflows.
+
+## Default-Deny Local Workflow
+
+In the default sandbox policy, Debian's Python packaging behavior matters:
+
+- `pip install ...` and `pip install --user ...` outside a virtualenv are blocked by PEP 668 (`externally-managed-environment`)
+- Fresh `python -m venv` environments include `pip` and `setuptools`, but not `wheel`
+- `python3-wheel` is installed system-wide by this stack, but a standard virtualenv does not see it unless you use `--system-site-packages`
+- `python -m venv --upgrade-deps` reaches PyPI, so it is not useful under the default-deny policy
+
+If you need to work on a checked-in local package without allowing a package registry, create the venv with system site
+packages so Debian's packaged build tooling remains visible, then disable build isolation for local installs:
+
+```bash
+python -m venv --system-site-packages .venv
+. .venv/bin/activate
+pip install --no-build-isolation -e .
+```
+
+This is less isolated than a normal virtualenv because Debian-packaged modules remain visible inside the environment.
+If you want a cleaner virtualenv, allow a private mirror or explicit package registry access and use the standard
+`python -m venv .venv` workflow instead.
+
+## Registry-Enabled Workflow
+
+Once a private mirror or package registry is allowed by policy, use a standard project-local virtualenv:
 
 ```bash
 python -m venv .venv
 . .venv/bin/activate
+pip install wheel  # if your project needs it
 ```
 
-For standalone Python CLIs outside a project venv, prefer `pipx` over `pip install --user`:
+Do not rely on `pip install --user`. Debian marks the system interpreter as externally managed, so those installs fail
+unless you opt into `--break-system-packages`, which this stack does not recommend.
 
-```bash
-pipx install ruff
-pipx install poetry
-```
-
-`pip install --user` still drops scripts into `~/.local/bin`, which is where agent images place tools like `codex`.
-That directory should stay reserved for agent binaries and should not be shared as a cross-agent volume.
-
-For a persistent local Python dev environment, add cache and pipx mounts to `.agent-sandbox/compose/user.override.yml`:
+For a persistent local Python dev environment, add a pip cache mount to `.agent-sandbox/compose/user.override.yml`:
 
 ```yaml
 services:
   agent:
     volumes:
       - pip-cache:/home/dev/.cache/pip
-      - pipx-home:/home/dev/.local/pipx
 
 volumes:
   pip-cache:
-  pipx-home:
 ```
 
 Package registry access is intentionally closed by default. That keeps public package download out of the baseline
@@ -75,5 +89,4 @@ domains:
   - files.pythonhosted.org
 ```
 
-Commands like `pip install ...` and `pipx install ...` that fetch from a registry will only work after you allow that
-registry.
+Commands like `pip install ...` that fetch from a registry will only work after you allow that registry.

--- a/docs/stacks/python.md
+++ b/docs/stacks/python.md
@@ -1,0 +1,79 @@
+# Python Stack
+
+See [Language stacks](./README.md) for the shared stack workflow.
+
+The Python stack installs these system packages:
+
+- `python3`
+- `python3-dev`
+- `python3-pip`
+- `python3-setuptools`
+- `python3-venv`
+- `python3-wheel`
+- `pipx`
+- `build-essential`
+- `pkg-config`
+- `libffi-dev`
+- `libssl-dev`
+
+It also configures these paths for the `dev` user:
+
+- `PATH=$HOME/.local/bin:$HOME/.local/pipx/bin:/usr/local/bin:$PATH`
+- `PIP_CACHE_DIR=$HOME/.cache/pip`
+- `PIPX_HOME=$HOME/.local/pipx`
+- `PIPX_BIN_DIR=$HOME/.local/pipx/bin`
+
+Use the system interpreter only to create project environments. For normal work, create a project-local virtualenv in
+your checkout:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+```
+
+For standalone Python CLIs outside a project venv, prefer `pipx` over `pip install --user`:
+
+```bash
+pipx install ruff
+pipx install poetry
+```
+
+`pip install --user` still drops scripts into `~/.local/bin`, which is where agent images place tools like `codex`.
+That directory should stay reserved for agent binaries and should not be shared as a cross-agent volume.
+
+For a persistent local Python dev environment, add cache and pipx mounts to `.agent-sandbox/compose/user.override.yml`:
+
+```yaml
+services:
+  agent:
+    volumes:
+      - pip-cache:/home/dev/.cache/pip
+      - pipx-home:/home/dev/.local/pipx
+
+volumes:
+  pip-cache:
+  pipx-home:
+```
+
+Package registry access is intentionally closed by default. That keeps public package download out of the baseline
+security posture while still giving you a complete local Python toolchain for checked-in code, local virtualenvs, and
+mounted artifacts.
+
+If you need package installs inside the sandbox, prefer allowing a private package mirror or proxy instead of public
+PyPI. For example:
+
+```yaml
+domains:
+  - python-packages.example.com
+```
+
+If you explicitly want public PyPI for local development, opt in by adding these domains to your policy:
+
+```yaml
+domains:
+  - pypi.org
+  - files.pythonhosted.org
+```
+
+Commands like `pip install ...` and `pipx install ...` that fetch from a registry will only work after you allow that
+registry.

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -109,6 +109,7 @@ COPY --chown=${USERNAME}:${USERNAME} tmux.conf /home/${USERNAME}/.tmux.conf
 # Copy firewall script, shell init, and utilities
 # Files in /etc/agent-sandbox are root-owned to prevent agent tampering
 COPY shell-init.sh /etc/agent-sandbox/shell-init.sh
+COPY path-helpers.sh /etc/agent-sandbox/path-helpers.sh
 COPY stacks/ /etc/agent-sandbox/stacks/
 COPY init-firewall.sh /usr/local/bin/
 COPY install-proxy-ca.sh /usr/local/bin/
@@ -126,8 +127,9 @@ USER root
 RUN mkdir -p /usr/local/etc
 COPY system-gitconfig /usr/local/etc/gitconfig
 
-RUN chmod 644 /etc/agent-sandbox/shell-init.sh /etc/zsh/zshrc /usr/local/etc/gitconfig && \
+RUN chmod 644 /etc/agent-sandbox/shell-init.sh /etc/agent-sandbox/path-helpers.sh /etc/zsh/zshrc /usr/local/etc/gitconfig && \
   chown root:root /etc/agent-sandbox/shell-init.sh && \
+  chown root:root /etc/agent-sandbox/path-helpers.sh && \
   chown root:root /etc/zsh/zshrc && \
   chown root:root /usr/local/etc/gitconfig && \
   chmod -R 755 /etc/agent-sandbox/stacks && \

--- a/images/base/path-helpers.sh
+++ b/images/base/path-helpers.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+path_prepend() {
+  PATH="$1${PATH:+:$PATH}"
+}
+
+path_append() {
+  PATH="${PATH:+$PATH:}$1"
+}
+
+path_dedupe() {
+  _agentbox_old_path="$PATH"
+  _agentbox_new_path=""
+
+  while [ -n "$_agentbox_old_path" ]; do
+    case "$_agentbox_old_path" in
+      *:*)
+        _agentbox_entry="${_agentbox_old_path%%:*}"
+        _agentbox_old_path="${_agentbox_old_path#*:}"
+        ;;
+      *)
+        _agentbox_entry="$_agentbox_old_path"
+        _agentbox_old_path=""
+        ;;
+    esac
+
+    [ -n "$_agentbox_entry" ] || continue
+    case ":$_agentbox_new_path:" in
+      *":$_agentbox_entry:"*) ;;
+      *) _agentbox_new_path="${_agentbox_new_path:+$_agentbox_new_path:}$_agentbox_entry" ;;
+    esac
+  done
+
+  PATH="$_agentbox_new_path"
+  unset _agentbox_old_path _agentbox_new_path _agentbox_entry
+}

--- a/images/base/stacks/go.sh
+++ b/images/base/stacks/go.sh
@@ -60,30 +60,7 @@ export GOPATH="$HOME/go"
 export GOBIN="$HOME/go/bin"
 export GOMODCACHE="$HOME/.cache/go-mod"
 export GOCACHE="$HOME/.cache/go-build"
-
-path_prepend() {
-  PATH="$1${PATH:+:$PATH}"
-}
-
-path_append() {
-  PATH="${PATH:+$PATH:}$1"
-}
-
-path_dedupe() {
-  local old_path="$PATH"
-  local new_path=""
-  local entry
-
-  for entry in ${(s/:/)old_path}; do
-    [ -n "$entry" ] || continue
-    case ":$new_path:" in
-      *":$entry:"*) ;;
-      *) new_path="${new_path:+$new_path:}$entry" ;;
-    esac
-  done
-
-  PATH="$new_path"
-}
+. /etc/agent-sandbox/path-helpers.sh
 
 path_prepend "/usr/local/go/bin"
 path_append "$GOBIN"
@@ -97,31 +74,7 @@ export GOPATH="$HOME/go"
 export GOBIN="$HOME/go/bin"
 export GOMODCACHE="$HOME/.cache/go-mod"
 export GOCACHE="$HOME/.cache/go-build"
-
-path_prepend() {
-  PATH="$1${PATH:+:$PATH}"
-}
-
-path_append() {
-  PATH="${PATH:+$PATH:}$1"
-}
-
-path_dedupe() {
-  local old_path="$PATH"
-  local new_path=""
-  local entry
-  local IFS=':'
-
-  for entry in $old_path; do
-    [ -n "$entry" ] || continue
-    case ":$new_path:" in
-      *":$entry:"*) ;;
-      *) new_path="${new_path:+$new_path:}$entry" ;;
-    esac
-  done
-
-  PATH="$new_path"
-}
+. /etc/agent-sandbox/path-helpers.sh
 
 path_prepend "/usr/local/go/bin"
 path_append "$GOBIN"

--- a/images/base/stacks/go.sh
+++ b/images/base/stacks/go.sh
@@ -60,7 +60,37 @@ export GOPATH="$HOME/go"
 export GOBIN="$HOME/go/bin"
 export GOMODCACHE="$HOME/.cache/go-mod"
 export GOCACHE="$HOME/.cache/go-build"
-export PATH="$HOME/.local/bin:/usr/local/go/bin:$PATH:$GOBIN:$GOPATH/bin"
+
+path_prepend() {
+  PATH="$1${PATH:+:$PATH}"
+}
+
+path_append() {
+  PATH="${PATH:+$PATH:}$1"
+}
+
+path_dedupe() {
+  local old_path="$PATH"
+  local new_path=""
+  local entry
+  local IFS=':'
+
+  for entry in $old_path; do
+    [ -n "$entry" ] || continue
+    case ":$new_path:" in
+      *":$entry:"*) ;;
+      *) new_path="${new_path:+$new_path:}$entry" ;;
+    esac
+  done
+
+  PATH="$new_path"
+}
+
+path_prepend "/usr/local/go/bin"
+path_append "$GOBIN"
+path_append "$GOPATH/bin"
+path_dedupe
+export PATH
 ZSHENV
 
 cat > /etc/profile.d/go.sh << 'PROFILE'
@@ -68,7 +98,37 @@ export GOPATH="$HOME/go"
 export GOBIN="$HOME/go/bin"
 export GOMODCACHE="$HOME/.cache/go-mod"
 export GOCACHE="$HOME/.cache/go-build"
-export PATH="$HOME/.local/bin:/usr/local/go/bin:$PATH:$GOBIN:$GOPATH/bin"
+
+path_prepend() {
+  PATH="$1${PATH:+:$PATH}"
+}
+
+path_append() {
+  PATH="${PATH:+$PATH:}$1"
+}
+
+path_dedupe() {
+  local old_path="$PATH"
+  local new_path=""
+  local entry
+  local IFS=':'
+
+  for entry in $old_path; do
+    [ -n "$entry" ] || continue
+    case ":$new_path:" in
+      *":$entry:"*) ;;
+      *) new_path="${new_path:+$new_path:}$entry" ;;
+    esac
+  done
+
+  PATH="$new_path"
+}
+
+path_prepend "/usr/local/go/bin"
+path_append "$GOBIN"
+path_append "$GOPATH/bin"
+path_dedupe
+export PATH
 PROFILE
 
 echo "Go stack installed: $(/usr/local/go/bin/go version)"

--- a/images/base/stacks/go.sh
+++ b/images/base/stacks/go.sh
@@ -49,26 +49,26 @@ tar -C /usr/local -xzf "${TMPDIR}/${TARBALL}"
 # Go directories for dev user
 mkdir -p \
   /home/dev/go \
+  /home/dev/go/bin \
   /home/dev/.cache/go-build \
   /home/dev/.cache/go-mod \
-  /home/dev/.config/go \
-  /home/dev/.local/bin
-chown -R dev:dev /home/dev/go /home/dev/.cache /home/dev/.config/go /home/dev/.local
+  /home/dev/.config/go
+chown -R dev:dev /home/dev/go /home/dev/.cache /home/dev/.config/go
 
 cat > /etc/zsh/zshenv.d/go.zsh << 'ZSHENV'
 export GOPATH="$HOME/go"
-export GOBIN="$HOME/.local/bin"
+export GOBIN="$HOME/go/bin"
 export GOMODCACHE="$HOME/.cache/go-mod"
 export GOCACHE="$HOME/.cache/go-build"
-export PATH="/usr/local/go/bin:$GOBIN:$GOPATH/bin:$PATH"
+export PATH="$HOME/.local/bin:/usr/local/go/bin:$PATH:$GOBIN:$GOPATH/bin"
 ZSHENV
 
 cat > /etc/profile.d/go.sh << 'PROFILE'
 export GOPATH="$HOME/go"
-export GOBIN="$HOME/.local/bin"
+export GOBIN="$HOME/go/bin"
 export GOMODCACHE="$HOME/.cache/go-mod"
 export GOCACHE="$HOME/.cache/go-build"
-export PATH="/usr/local/go/bin:$GOBIN:$GOPATH/bin:$PATH"
+export PATH="$HOME/.local/bin:/usr/local/go/bin:$PATH:$GOBIN:$GOPATH/bin"
 PROFILE
 
 echo "Go stack installed: $(/usr/local/go/bin/go version)"

--- a/images/base/stacks/go.sh
+++ b/images/base/stacks/go.sh
@@ -73,9 +73,8 @@ path_dedupe() {
   local old_path="$PATH"
   local new_path=""
   local entry
-  local IFS=':'
 
-  for entry in $old_path; do
+  for entry in ${(s/:/)old_path}; do
     [ -n "$entry" ] || continue
     case ":$new_path:" in
       *":$entry:"*) ;;

--- a/images/base/stacks/go.sh
+++ b/images/base/stacks/go.sh
@@ -64,7 +64,6 @@ export GOCACHE="$HOME/.cache/go-build"
 
 path_prepend "/usr/local/go/bin"
 path_append "$GOBIN"
-path_append "$GOPATH/bin"
 path_dedupe
 export PATH
 ZSHENV
@@ -78,7 +77,6 @@ export GOCACHE="$HOME/.cache/go-build"
 
 path_prepend "/usr/local/go/bin"
 path_append "$GOBIN"
-path_append "$GOPATH/bin"
 path_dedupe
 export PATH
 PROFILE

--- a/images/base/stacks/python.sh
+++ b/images/base/stacks/python.sh
@@ -13,7 +13,6 @@ apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   libffi-dev \
   libssl-dev \
-  pipx \
   pkg-config \
   python3 \
   python3-dev \
@@ -31,27 +30,69 @@ ln -sf /usr/bin/pip3 /usr/local/bin/pip
 mkdir -p \
   /home/dev/.cache/pip \
   /home/dev/.config/pip \
-  /home/dev/.local/pipx/bin \
   /home/dev/.local/bin
 chown -R dev:dev /home/dev/.cache /home/dev/.config/pip /home/dev/.local
 
 # PATH entry for Python-managed tools plus shared cache/tooling defaults.
-# Keep agent binaries in ~/.local/bin ahead of pipx-installed tools so a
-# user-installed CLI cannot accidentally shadow the active agent binary.
+# Keep agent binaries in ~/.local/bin ahead of any later user-installed tools.
 cat > /etc/zsh/zshenv.d/python.zsh << 'ZSHENV'
-export PATH="$HOME/.local/bin:$HOME/.local/pipx/bin:/usr/local/bin:$PATH"
+path_prepend() {
+  PATH="$1${PATH:+:$PATH}"
+}
+
+path_dedupe() {
+  local old_path="$PATH"
+  local new_path=""
+  local entry
+  local IFS=':'
+
+  for entry in $old_path; do
+    [ -n "$entry" ] || continue
+    case ":$new_path:" in
+      *":$entry:"*) ;;
+      *) new_path="${new_path:+$new_path:}$entry" ;;
+    esac
+  done
+
+  PATH="$new_path"
+}
+
+path_prepend "/usr/local/bin"
+path_prepend "$HOME/.local/bin"
+path_dedupe
+export PATH
 export PIP_CACHE_DIR="$HOME/.cache/pip"
 export PIP_DISABLE_PIP_VERSION_CHECK=1
-export PIPX_HOME="$HOME/.local/pipx"
-export PIPX_BIN_DIR="$HOME/.local/pipx/bin"
 ZSHENV
 
 cat > /etc/profile.d/python.sh << 'PROFILE'
-export PATH="$HOME/.local/bin:$HOME/.local/pipx/bin:/usr/local/bin:$PATH"
+path_prepend() {
+  PATH="$1${PATH:+:$PATH}"
+}
+
+path_dedupe() {
+  local old_path="$PATH"
+  local new_path=""
+  local entry
+  local IFS=':'
+
+  for entry in $old_path; do
+    [ -n "$entry" ] || continue
+    case ":$new_path:" in
+      *":$entry:"*) ;;
+      *) new_path="${new_path:+$new_path:}$entry" ;;
+    esac
+  done
+
+  PATH="$new_path"
+}
+
+path_prepend "/usr/local/bin"
+path_prepend "$HOME/.local/bin"
+path_dedupe
+export PATH
 export PIP_CACHE_DIR="$HOME/.cache/pip"
 export PIP_DISABLE_PIP_VERSION_CHECK=1
-export PIPX_HOME="$HOME/.local/pipx"
-export PIPX_BIN_DIR="$HOME/.local/pipx/bin"
 PROFILE
 
 echo "Python stack installed: $(python3 --version)"

--- a/images/base/stacks/python.sh
+++ b/images/base/stacks/python.sh
@@ -36,25 +36,7 @@ chown -R dev:dev /home/dev/.cache /home/dev/.config/pip /home/dev/.local
 # PATH entry for Python-managed tools plus shared cache/tooling defaults.
 # Keep agent binaries in ~/.local/bin ahead of any later user-installed tools.
 cat > /etc/zsh/zshenv.d/python.zsh << 'ZSHENV'
-path_prepend() {
-  PATH="$1${PATH:+:$PATH}"
-}
-
-path_dedupe() {
-  local old_path="$PATH"
-  local new_path=""
-  local entry
-
-  for entry in ${(s/:/)old_path}; do
-    [ -n "$entry" ] || continue
-    case ":$new_path:" in
-      *":$entry:"*) ;;
-      *) new_path="${new_path:+$new_path:}$entry" ;;
-    esac
-  done
-
-  PATH="$new_path"
-}
+. /etc/agent-sandbox/path-helpers.sh
 
 path_prepend "/usr/local/bin"
 path_prepend "$HOME/.local/bin"
@@ -65,26 +47,7 @@ export PIP_DISABLE_PIP_VERSION_CHECK=1
 ZSHENV
 
 cat > /etc/profile.d/python.sh << 'PROFILE'
-path_prepend() {
-  PATH="$1${PATH:+:$PATH}"
-}
-
-path_dedupe() {
-  local old_path="$PATH"
-  local new_path=""
-  local entry
-  local IFS=':'
-
-  for entry in $old_path; do
-    [ -n "$entry" ] || continue
-    case ":$new_path:" in
-      *":$entry:"*) ;;
-      *) new_path="${new_path:+$new_path:}$entry" ;;
-    esac
-  done
-
-  PATH="$new_path"
-}
+. /etc/agent-sandbox/path-helpers.sh
 
 path_prepend "/usr/local/bin"
 path_prepend "$HOME/.local/bin"

--- a/images/base/stacks/python.sh
+++ b/images/base/stacks/python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Python 3 + pip + venv from apt
+# Install a Python 3 development environment from apt
 # Usage: python.sh [version]
 #   version: not used (apt provides system Python), accepted for interface consistency
 set -euo pipefail
@@ -10,21 +10,48 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  libffi-dev \
+  libssl-dev \
+  pipx \
+  pkg-config \
   python3 \
+  python3-dev \
   python3-pip \
+  python3-setuptools \
   python3-venv \
+  python3-wheel \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Convenience symlinks
 ln -sf /usr/bin/python3 /usr/local/bin/python
+ln -sf /usr/bin/pip3 /usr/local/bin/pip
 
-# PATH entry (python3 is already in /usr/bin, but pip may install to /usr/local/bin)
+# Python tooling and caches live under the dev user's home directory.
+mkdir -p \
+  /home/dev/.cache/pip \
+  /home/dev/.config/pip \
+  /home/dev/.local/pipx/bin \
+  /home/dev/.local/bin
+chown -R dev:dev /home/dev/.cache /home/dev/.config/pip /home/dev/.local
+
+# PATH entry for Python-managed tools plus shared cache/tooling defaults.
+# Keep agent binaries in ~/.local/bin ahead of pipx-installed tools so a
+# user-installed CLI cannot accidentally shadow the active agent binary.
 cat > /etc/zsh/zshenv.d/python.zsh << 'ZSHENV'
-export PATH="/usr/local/bin:$PATH"
+export PATH="$HOME/.local/bin:$HOME/.local/pipx/bin:/usr/local/bin:$PATH"
+export PIP_CACHE_DIR="$HOME/.cache/pip"
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+export PIPX_HOME="$HOME/.local/pipx"
+export PIPX_BIN_DIR="$HOME/.local/pipx/bin"
 ZSHENV
 
 cat > /etc/profile.d/python.sh << 'PROFILE'
-export PATH="/usr/local/bin:$PATH"
+export PATH="$HOME/.local/bin:$HOME/.local/pipx/bin:/usr/local/bin:$PATH"
+export PIP_CACHE_DIR="$HOME/.cache/pip"
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+export PIPX_HOME="$HOME/.local/pipx"
+export PIPX_BIN_DIR="$HOME/.local/pipx/bin"
 PROFILE
 
 echo "Python stack installed: $(python3 --version)"

--- a/images/base/stacks/python.sh
+++ b/images/base/stacks/python.sh
@@ -44,9 +44,8 @@ path_dedupe() {
   local old_path="$PATH"
   local new_path=""
   local entry
-  local IFS=':'
 
-  for entry in $old_path; do
+  for entry in ${(s/:/)old_path}; do
     [ -n "$entry" ] || continue
     case ":$new_path:" in
       *":$entry:"*) ;;


### PR DESCRIPTION
## Summary

This PR makes the local Python development story more useful for both product users and maintainers working on proxy-side Python code.

- add a dedicated Python test environment in `Dockerfile.dev` for local proxy-addon work, including `mitmproxy`, `pytest`, and `PyYAML`
- make the shipped Python stack more practical for default-deny sandbox use by documenting Debian `venv` behavior, PEP 668 limits, and the offline `--system-site-packages` workflow
- remove `pipx` from the shipped Python stack and simplify the Python path layout around `~/.local/bin`
- move Go-installed tools to `$HOME/go/bin` and update the Go stack docs and local compose mounts so Go tools do not mask agent binaries such as `codex`
- add common Python local-dev artifacts to `.gitignore`
- refresh README language around supported agents and clarify that public package registries such as PyPI remain opt-in
- normalize the local compose files for this repo's dev environment

