### PR TITLE
Fix help flags for custom CLI parsers

### DIFF
--- a/internal/cli/bump.go
+++ b/internal/cli/bump.go
@@ -15,7 +15,11 @@ func newBumpCommand(deps commandDeps) *cobra.Command {
 		Short:              "Refresh managed image digests",
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfRequested(cmd, args); handled {
+				return err
+			}
+
 			repoRoot, err := runtime.FindRepoRoot(deps.workingDir)
 			if err != nil {
 				return err

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -16,12 +16,16 @@ type destroyArgs struct {
 }
 
 func newDestroyCommand(opts Options, deps commandDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                "destroy",
 		Short:              "Remove sandbox files and resources",
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfRequested(cmd, args); handled {
+				return err
+			}
+
 			parsed, err := parseDestroyArgs(args)
 			if err != nil {
 				return err
@@ -66,6 +70,10 @@ func newDestroyCommand(opts Options, deps commandDeps) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+
+	return cmd
 }
 
 func parseDestroyArgs(args []string) (destroyArgs, error) {

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -40,12 +40,16 @@ func newEditCommand(opts Options, deps commandDeps) *cobra.Command {
 }
 
 func newEditComposeCommand(opts Options, deps commandDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                "compose",
 		Short:              "Edit compose overrides",
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfRequested(cmd, args); handled {
+				return err
+			}
+
 			parsed, err := parseEditComposeArgs(args)
 			if err != nil {
 				return err
@@ -121,15 +125,23 @@ func newEditComposeCommand(opts Options, deps commandDeps) *cobra.Command {
 			return runComposeCommand(cmd.Context(), deps.runner, stack, cmd, "up", "-d")
 		},
 	}
+
+	cmd.Flags().Bool("no-restart", false, "Do not restart running containers after editing")
+
+	return cmd
 }
 
 func newEditPolicyCommand(opts Options, deps commandDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                "policy",
 		Short:              "Edit policy overrides",
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfRequested(cmd, args); handled {
+				return err
+			}
+
 			parsed, err := parseEditPolicyArgs(args)
 			if err != nil {
 				return err
@@ -215,6 +227,11 @@ func newEditPolicyCommand(opts Options, deps commandDeps) *cobra.Command {
 			return runComposeCommand(cmd.Context(), deps.runner, stack, cmd, "kill", "-s", "HUP", "proxy")
 		},
 	}
+
+	cmd.Flags().String("agent", "", "Agent-specific policy to edit ("+runtime.SupportedAgentsDisplay()+")")
+	cmd.Flags().String("mode", "", "Runtime mode policy surface (cli devcontainer)")
+
+	return cmd
 }
 
 func parseEditComposeArgs(args []string) (editComposeArgs, error) {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,23 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func showHelpIfRequested(cmd *cobra.Command, args []string) (bool, error) {
+	for _, arg := range args {
+		if isHelpFlag(arg) {
+			return true, cmd.Help()
+		}
+	}
+	return false, nil
+}
+
+func showHelpIfOnlyArg(cmd *cobra.Command, args []string) (bool, error) {
+	if len(args) == 1 && isHelpFlag(args[0]) {
+		return true, cmd.Help()
+	}
+	return false, nil
+}
+
+func isHelpFlag(arg string) bool {
+	return arg == "-h" || arg == "--help"
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -38,12 +38,16 @@ type initArgs struct {
 }
 
 func newInitCommand(opts Options, deps commandDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                "init",
 		Short:              "Initialize a project sandbox",
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfRequested(cmd, args); handled {
+				return err
+			}
+
 			parsed, err := parseInitArgs(args)
 			if err != nil {
 				return err
@@ -110,6 +114,15 @@ func newInitCommand(opts Options, deps commandDeps) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().String("name", "", "Project name for generated runtime metadata")
+	cmd.Flags().String("path", ".", "Project directory to initialize")
+	cmd.Flags().String("agent", "", "Agent to configure ("+runtime.SupportedAgentsDisplay()+")")
+	cmd.Flags().String("mode", "", "Runtime mode (cli devcontainer)")
+	cmd.Flags().String("ide", "", "Devcontainer IDE ("+runtime.SupportedIDEsDisplay()+")")
+	cmd.Flags().Bool("batch", false, "Run without prompts; requires --agent and --mode")
+
+	return cmd
 }
 
 func parseInitArgs(args []string) (initArgs, error) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -23,6 +23,72 @@ func TestRootCommandIncludesExpectedCommands(t *testing.T) {
 	}
 }
 
+func TestDisabledFlagParsingCommandsSupportHelpFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "init long help", args: []string{"init", "--help"}, want: "Initialize a project sandbox"},
+		{name: "init short help", args: []string{"init", "-h"}, want: "Initialize a project sandbox"},
+		{name: "switch", args: []string{"switch", "--help"}, want: "Switch the active agent"},
+		{name: "edit compose", args: []string{"edit", "compose", "--help"}, want: "Edit compose overrides"},
+		{name: "edit policy", args: []string{"edit", "policy", "--help"}, want: "Edit policy overrides"},
+		{name: "bump", args: []string{"bump", "--help"}, want: "Refresh managed image digests"},
+		{name: "destroy", args: []string{"destroy", "--help"}, want: "Remove sandbox files and resources"},
+		{name: "up", args: []string{"up", "--help"}, want: "Start the sandbox runtime"},
+		{name: "down", args: []string{"down", "--help"}, want: "Stop the sandbox runtime"},
+		{name: "logs", args: []string{"logs", "--help"}, want: "Show runtime logs"},
+		{name: "compose", args: []string{"compose", "--help"}, want: "Run docker compose against the sandbox stack"},
+		{name: "exec", args: []string{"exec", "--help"}, want: "Open a shell in the sandbox container"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRootCommand(Options{WorkingDir: t.TempDir()})
+			stdout, stderr, err := testutil.ExecuteCommand(cmd, tt.args...)
+			if err != nil {
+				t.Fatalf("help command failed: %v", err)
+			}
+			if stderr != "" {
+				t.Fatalf("expected no stderr, got %q", stderr)
+			}
+			if !strings.Contains(stdout, tt.want) {
+				t.Fatalf("expected help output to contain %q, got %q", tt.want, stdout)
+			}
+		})
+	}
+}
+
+func TestCustomParsedCommandHelpListsOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{name: "init", args: []string{"init", "--help"}, want: []string{"--agent", "--batch", "--mode", "--path"}},
+		{name: "switch", args: []string{"switch", "--help"}, want: []string{"--agent"}},
+		{name: "edit compose", args: []string{"edit", "compose", "--help"}, want: []string{"--no-restart"}},
+		{name: "edit policy", args: []string{"edit", "policy", "--help"}, want: []string{"--agent", "--mode"}},
+		{name: "destroy", args: []string{"destroy", "--help"}, want: []string{"--force"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRootCommand(Options{WorkingDir: t.TempDir()})
+			stdout, _, err := testutil.ExecuteCommand(cmd, tt.args...)
+			if err != nil {
+				t.Fatalf("help command failed: %v", err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("expected help output to contain %q, got %q", want, stdout)
+				}
+			}
+		})
+	}
+}
+
 func TestVersionCommandPrintsBuildMetadata(t *testing.T) {
 	cmd := NewRootCommand(Options{
 		Version: version.Info{

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -66,7 +66,7 @@ func TestCustomParsedCommandHelpListsOptions(t *testing.T) {
 		args []string
 		want []string
 	}{
-		{name: "init", args: []string{"init", "--help"}, want: []string{"--agent", "--batch", "--mode", "--path"}},
+		{name: "init", args: []string{"init", "--help"}, want: []string{"--agent", "--batch", "--ide", "--mode", "--name", "--path"}},
 		{name: "switch", args: []string{"switch", "--help"}, want: []string{"--agent"}},
 		{name: "edit compose", args: []string{"edit", "compose", "--help"}, want: []string{"--no-restart"}},
 		{name: "edit policy", args: []string{"edit", "policy", "--help"}, want: []string{"--agent", "--mode"}},

--- a/internal/cli/runtime_commands.go
+++ b/internal/cli/runtime_commands.go
@@ -61,6 +61,10 @@ func newRuntimeComposeCommand(use string, short string, commandName string, pref
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfOnlyArg(cmd, args); handled {
+				return err
+			}
+
 			return runComposePassthrough(cmd, deps, commandName, append(append([]string{}, prefix...), args...))
 		},
 	}
@@ -97,6 +101,10 @@ func newExecCommand(deps commandDeps) *cobra.Command {
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfOnlyArg(cmd, args); handled {
+				return err
+			}
+
 			stack, err := resolveComposeStackForCommand(deps, "exec")
 			if err != nil {
 				return err

--- a/internal/cli/runtime_commands_test.go
+++ b/internal/cli/runtime_commands_test.go
@@ -66,6 +66,20 @@ func TestComposeCommandCallsRuntimeSyncOnlyForMutatingCommands(t *testing.T) {
 	}
 }
 
+func TestComposeNestedHelpPassesThroughToDockerCompose(t *testing.T) {
+	repoRoot := layeredCLIRepo(t)
+	runner := &fakeRunner{}
+
+	cmd := NewRootCommand(Options{WorkingDir: repoRoot, Runner: runner})
+	_, _, err := testutil.ExecuteCommand(cmd, "compose", "up", "--help")
+	if err != nil {
+		t.Fatalf("compose help passthrough failed: %v", err)
+	}
+
+	want := []string{"docker", "compose", "-f", runtime.CLIBaseComposeFile(repoRoot), "-f", runtime.CLIAgentComposeFile(repoRoot, "codex"), "-f", runtime.CLIUserOverrideFile(repoRoot), "-f", runtime.CLIUserAgentOverrideFile(repoRoot, "codex"), "up", "--help"}
+	assertSingleRunCall(t, runner, want)
+}
+
 func TestComposeCommandReResolvesFilesAfterDefaultRuntimeSync(t *testing.T) {
 	repoRoot := t.TempDir()
 	testutil.WriteFile(t, repoRoot, ".git", "gitdir: /tmp/worktree\n")

--- a/internal/cli/switch.go
+++ b/internal/cli/switch.go
@@ -17,12 +17,16 @@ type switchArgs struct {
 }
 
 func newSwitchCommand(opts Options, deps commandDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                "switch",
 		Short:              "Switch the active agent",
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if handled, err := showHelpIfRequested(cmd, args); handled {
+				return err
+			}
+
 			parsed, err := parseSwitchArgs(args)
 			if err != nil {
 				return err
@@ -157,6 +161,10 @@ func newSwitchCommand(opts Options, deps commandDeps) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().String("agent", "", "Agent to activate ("+runtime.SupportedAgentsDisplay()+")")
+
+	return cmd
 }
 
 func parseSwitchArgs(args []string) (switchArgs, error) {


### PR DESCRIPTION
Summary:
- Handles -h/--help for commands using DisableFlagParsing.
- Registers custom parsed flags so help output lists real options.
- Preserves nested docker compose help passthrough.

Tests:
- go test ./internal/cli
- go test ./...

Fixes #151 