### PR TITLE
Reorder milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,36 +83,7 @@ curl -fsSL https://github.com/mattolson/agent-sandbox/releases/latest/download/i
   sh -s -- --version v0.14.0 --install-dir /usr/local/bin
 ```
 
-#### Manual install
-
-```bash
-OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-ARCH="$(uname -m)"
-
-case "$ARCH" in
-  x86_64) ARCH=amd64 ;;
-  arm64|aarch64) ARCH=arm64 ;;
-  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-esac
-
-ASSET="agentbox_${OS}_${ARCH}.tar.gz"
-
-cd /tmp
-curl -fsSLO \
-  "https://github.com/mattolson/agent-sandbox/releases/latest/download/${ASSET}"
-tar -xzf "${ASSET}"
-mkdir -p "${HOME}/.local/bin"
-install -m 755 "/tmp/agentbox_${OS}_${ARCH}/agentbox" "${HOME}/.local/bin/agentbox"
-"${HOME}/.local/bin/agentbox" version
-```
-
-If you want to verify the archive before installing it, download `agentbox_checksums.txt` from the same release and
-compare the checksum for `${ASSET}` against `shasum -a 256 "${ASSET}"` on macOS or `sha256sum "${ASSET}"` on Linux.
-
-If you want a pinned install instead of "latest", use the versioned assets attached to a specific release tag such as
-`agentbox_<version>_<os>_<arch>.tar.gz` together with `agentbox_<version>_checksums.txt`.
-
-If `~/.local/bin` is not already on your `PATH`, add it in your shell profile before running `agentbox` directly.
+For the full manual install process, see the [installation notes](docs/cli.md#manual-install).
 
 ### 3. Initialize the sandbox for your project
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 Run AI coding agents in a locked-down local sandbox with:
 
-- Minimal filesystem access (read/write access to only the repository directory)
-- Configurable egress policy enforced by sidecar proxy (hosts plus optional scheme, method, path, and query rules)
+- Minimal filesystem access (read/write access to only your repository directory)
+- Configurable network egress policy enforced by a sidecar proxy (restrict by hostname, as well as other attributes, like scheme, method, path, and query string)
 - Iptables firewall preventing direct outbound (all traffic must go through the proxy)
 - Reproducible environments (Debian container with pinned dependencies)
 - Persistent volume for agent state - auth and config preserved across container restarts
-- Ability to easily switch between agents without losing state
+- Ability to easily switch back and forth between agents without losing state
 - Support for CLI and devcontainers (including VS Code and JetBrains IDEs)
 
 Target platform: [Colima](https://github.com/abiosoft/colima) + [Docker Engine](https://docs.docker.com/engine/) on Apple Silicon. Should work with any Docker-compatible runtime.
@@ -45,7 +45,7 @@ Target platform: [Colima](https://github.com/abiosoft/colima) + [Docker Engine](
 
 ### 1. Install prerequisites
 
-You need a VM and Docker (along with docker-compose and docker-buildx) installed. This can be done in a variety of ways.
+You need a VM and Docker installed. This can be done in a variety of ways.
 
 * [Colima](https://colima.run/)
 * [Podman](https://podman.io/)
@@ -62,11 +62,11 @@ Instructions that follow are for Colima.
 # docker-buildx for building images locally
 brew install colima docker docker-compose docker-buildx
 
-# Start the virtual machine
-colima start --edit
+# Start the virtual machine. Pass `--edit` to configure the machine first.
+colima start
 ```
 
-### 2. Install agent-sandbox CLI
+### 2. Install agentbox CLI
 
 Download the `agentbox` binary from [GitHub Releases](https://github.com/mattolson/agent-sandbox/releases).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,40 @@
 
 Reference for the Go `agentbox` CLI.
 
+## Manual Install
+
+Download the platform archive directly from [GitHub Releases](https://github.com/mattolson/agent-sandbox/releases) if
+you do not want to use the installer script.
+
+```bash
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "$ARCH" in
+  x86_64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+ASSET="agentbox_${OS}_${ARCH}.tar.gz"
+
+cd /tmp
+curl -fsSLO \
+  "https://github.com/mattolson/agent-sandbox/releases/latest/download/${ASSET}"
+tar -xzf "${ASSET}"
+mkdir -p "${HOME}/.local/bin"
+install -m 755 "/tmp/agentbox_${OS}_${ARCH}/agentbox" "${HOME}/.local/bin/agentbox"
+"${HOME}/.local/bin/agentbox" version
+```
+
+To verify the archive before installing it, download `agentbox_checksums.txt` from the same release and compare the
+checksum for `${ASSET}` against `shasum -a 256 "${ASSET}"` on macOS or `sha256sum "${ASSET}"` on Linux.
+
+For a pinned install instead of "latest", use the versioned assets attached to a specific release tag, such as
+`agentbox_<version>_<os>_<arch>.tar.gz` together with `agentbox_<version>_checksums.txt`.
+
+If `~/.local/bin` is not already on your `PATH`, add it in your shell profile before running `agentbox` directly.
+
 ## Commands
 
 ### `agentbox init`

--- a/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
@@ -21,8 +21,8 @@ request-aware rules, semantic GitHub service expansion, hot reload, integration 
 - Structured logging, docs, examples, and automated coverage for the new behavior
 
 **Excluded:**
-- GitHub REST wrapper work from `m15`
-- Secret injection, header substitution, or other credential features from `m16`
+- Secret injection, header substitution, or other credential features from `m15`
+- GitHub REST wrapper work from `m16`
 - Monitoring UI or interactive unblock workflows from `m17`
 - Non-HTTP protocols
 - Header matching and request body inspection. For now, a matched URL rule implies the endpoint is trusted to receive

--- a/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/execution-log.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/execution-log.md
@@ -166,7 +166,7 @@ expanded fragments participate in the existing host-record merge path.
 ## 2026-04-16 15:12 UTC - Drafted the task plan and locked the intended boundary
 
 Reviewed the `m14` milestone plan, project learnings, decision record `005`, the current `render-policy`
-implementation, the `m14.2` matcher boundary, and the downstream `m15` GitHub wrapper goals. The main planning
+implementation, the `m14.2` matcher boundary, and the downstream `m16` GitHub wrapper goals. The main planning
 conclusion is that `m14.3` should not push GitHub-specific behavior into the matcher. Service semantics belong at
 render time and should compile into the same canonical host-record IR that authored `domains` already use.
 

--- a/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/task.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/task.md
@@ -181,9 +181,9 @@ For GitHub `git`, the intended `readonly` mapping is:
 
 That keeps clone and fetch working under `readonly: true` while still excluding push.
 
-That is enough to keep repo-scoped Git transport visible in the URL path and to support later credential work without
-quietly broadening the host allowlist. `m15` remains about the higher-level REST wrapper surface; adding Git smart-HTTP
-to `m14.3` does not replace that milestone.
+That is enough to keep repo-scoped Git transport visible in the URL path and to support `m15` credential injection
+without quietly broadening the host allowlist. `m16` remains about the higher-level REST wrapper surface; adding Git
+smart-HTTP to `m14.3` does not replace that milestone.
 
 #### Merge And Override Semantics
 
@@ -353,5 +353,5 @@ Test runs after the simplify pass:
 - If future services duplicate the pattern of "named surfaces plus scoped selectors," revisit whether the per-service
   Python expander can be factored into a shared helper; `m14.3` deliberately resisted that abstraction until a second
   rich service exists.
-- Downstream `m15` still owns the GitHub REST wrapper work; the repo-scoped `api` surface added here intentionally
-  stops at URL-shape filtering and leaves credential-aware behavior to that milestone.
+- Downstream `m16` still owns the GitHub REST wrapper work; the repo-scoped `api` surface added here intentionally
+  stops at URL-shape filtering. Credential-aware behavior belongs to `m15`.

--- a/docs/plan/milestones/m16-github-rest-wrapper/milestone.md
+++ b/docs/plan/milestones/m16-github-rest-wrapper/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m15 - GitHub REST Wrapper
+# Milestone: m16 - GitHub REST Wrapper
 
 Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
 URLs and can be constrained by `m14` policies. The goal is not to replace stock `gh` wholesale; it is to provide a
@@ -22,7 +22,7 @@ policy model it was not designed for.
 - Provide a stable, documented wrapper surface instead of asking users to memorize raw REST routes
 - Make the supported subset explicit and document what remains unsupported because it depends on GraphQL or broader
   trust assumptions
-- Start with existing/manual auth flows and leave tighter integration with later credential milestones as follow-up work
+- Use `m15` proxy-side credential injection where practical instead of storing GitHub tokens in the agent container
 
 ## Out of Scope
 
@@ -72,10 +72,10 @@ constrain access via URL-based rules.
 
 ### Auth
 
-This milestone does not need to invent a new credential path. It can start by working with the existing/manual token
-flows that are already available in the environment. Later milestones can improve the auth story:
+This milestone should not invent a second credential path. It should use `m15` proxy-side credential injection where
+the wrapper's REST calls can be matched safely by host, method, and path. Residual flows that require the client to
+receive credential material belong in later helper work:
 
-- `m16` for proxy-side secret injection
 - `m18` for residual helper-based flows
 
 ### Distribution
@@ -92,7 +92,7 @@ This milestone may later become its own open-source project. The current rationa
 an obvious standalone-binary equivalent to `gh` that intentionally stays on REST-only endpoints for use in constrained
 environments with network proxy inspection.
 
-That project-boundary decision is deferred for now. `m15` should proceed in a way that keeps extraction feasible later:
+That project-boundary decision is deferred for now. `m16` should proceed in a way that keeps extraction feasible later:
 
 - keep the wrapper surface narrow and well documented
 - avoid coupling the command surface too tightly to Agent Sandbox internals
@@ -108,6 +108,7 @@ To be broken down when work begins. Rough outline:
   alternative)
 - Implement the wrapper on REST calls only
 - Add policy examples showing single-repo access under `m14`
+- Add credential-injection examples that reuse the `m15` model where practical
 - Document unsupported workflows that still require stock `gh` or broader trust
 - Test the wrapper against representative GitHub workflows and failure modes
 
@@ -130,4 +131,4 @@ To be broken down when work begins. Rough outline:
 - The supported wrapper commands keep repo identity visible in URL paths and are compatible with `m14` policy matching
 - The supported subset and unsupported GraphQL-dependent workflows are documented clearly
 - Policy examples exist for constraining the wrapper to a single GitHub repository
-- The auth story for the wrapper is documented, even if richer secret handling is deferred to later milestones
+- The auth story for the wrapper is documented and reuses `m15` proxy-side injection where practical

--- a/docs/plan/milestones/m18-host-credential-service/milestone.md
+++ b/docs/plan/milestones/m18-host-credential-service/milestone.md
@@ -1,10 +1,10 @@
 # m18: Host Credential Service
 
-Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m16-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
+Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m15-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
 
 ## Problem
 
-`m16-proxy-secret-injection` should be the primary path for HTTP-native credentials, especially git over HTTPS and other request-decorated auth patterns. Some flows still do not fit that model:
+`m15-proxy-secret-injection` should be the primary path for HTTP-native credentials, especially git over HTTPS and other request-decorated auth patterns. Some flows still do not fit that model:
 
 - Browser-driven or device-code login flows where the client expects local auth state
 - Tools that insist on a credential-helper protocol instead of pure outbound request transformation
@@ -13,7 +13,7 @@ Run a narrower host-side credential service for auth flows that cannot be handle
 
 ## Goals
 
-- Secondary credential path for cases `m16` cannot cover
+- Secondary credential path for cases `m15` cannot cover
 - Credentials stored in the host's native credential store, never persisted on disk inside the container
 - Support credential-helper-shaped clients and similar local-delivery flows
 - Minimal configuration: the service starts when the sandbox starts and stops when it stops
@@ -51,12 +51,12 @@ Git's credential helper protocol is still the main reference protocol for this m
 - `store` - Save credentials after successful authentication
 - `erase` - Remove stored credentials
 
-The HTTP wrapper translates these into `POST /get`, `POST /store`, `POST /erase` with the key=value body. If a later client needs a different helper-facing protocol, add it only if `m16` cannot cover the use case.
+The HTTP wrapper translates these into `POST /get`, `POST /store`, `POST /erase` with the key=value body. If a later client needs a different helper-facing protocol, add it only if `m15` cannot cover the use case.
 
 ### Security considerations
 
 - The service should only accept connections from the container network, not the wider host network
-- Consider scoping credential lookups to domains or services not already handled by `m16`
+- Consider scoping credential lookups to domains or services not already handled by `m15`
 - The raw token transits the Docker bridge network in the HTTP response. This is the same trust boundary as the proxy CA cert distribution, which already happens over this path
 - Rate limiting or audit logging on the host service would help detect credential abuse
 
@@ -76,13 +76,13 @@ The service could run as:
 - A host-side process started by `agentbox exec` (more natural, direct access to host keychain)
 - Part of the proxy sidecar (reuses existing infrastructure, but mixes concerns)
 
-The `agentbox exec` approach is the most natural fit. The CLI already manages the compose lifecycle. It can start the credential service before `docker compose up` and stop it after `docker compose down`. This milestone should only be attempted after `m16` settles the primary proxy-based path, so the helper solves the residual set of unsupported flows instead of becoming a competing default.
+The `agentbox exec` approach is the most natural fit. The CLI already manages the compose lifecycle. It can start the credential service before `docker compose up` and stop it after `docker compose down`. This milestone should only be attempted after `m15` settles the primary proxy-based path, so the helper solves the residual set of unsupported flows instead of becoming a competing default.
 
 ## Tasks
 
 To be broken down when work begins. Rough outline:
 
-- Identify the residual auth flows that still cannot be handled by `m16`
+- Identify the residual auth flows that still cannot be handled by `m15`
 - Design and implement the HTTP credential protocol wrapper
 - Implement the host-side service (Go, to match the planned CLI language)
 - Implement the container-side shim (shell script using curl, or a small Go binary)
@@ -94,15 +94,15 @@ To be broken down when work begins. Rough outline:
 ## Open Questions
 
 - Should the service require an auth token of its own to prevent other containers on the same Docker network from using it?
-- Which real workflows remain after `m16` lands, and are they important enough to justify the helper complexity?
+- Which real workflows remain after `m15` lands, and are they important enough to justify the helper complexity?
 - Should credential scoping (allowlist-only domains) be enforced at the service level or left to the proxy?
 - Is HTTP over the Docker bridge acceptable, or should the service use a Unix socket mounted into the container?
 - Should the service support credential caching (short TTL) to reduce round-trips to the host keychain?
 
 ## Definition of Done
 
-- [ ] At least one important unsupported flow after `m16` can authenticate using the host credential service with no tokens on disk in the container
-- [ ] `m16` is documented as the primary credential path and this service is documented as the fallback path
+- [ ] At least one important unsupported flow after `m15` can authenticate using the host credential service with no tokens on disk in the container
+- [ ] `m15` is documented as the primary credential path and this service is documented as the fallback path
 - [ ] Works on macOS (Colima) out of the box
 - [ ] Documented for Windows and Linux desktop
 - [ ] Graceful fallback when the service is unavailable (clear error message, not silent failure)

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -230,32 +230,12 @@ filtering.
 - SIGHUP-based policy hot reload through `agentbox proxy reload` and `agentbox edit policy`
 - Schema docs, examples, troubleshooting guidance, and proxy integration coverage
 
-### m15-github-rest-wrapper
-
-Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
-URLs and can be constrained by `m14` policies.
-
-**Goals:**
-- Support a curated set of common, repo-scoped GitHub workflows using REST-only endpoints
-- Keep repo identity explicit in URL paths so single-repo allowlists are practical under `m14`
-- Prefer a thin wrapper over full parity with stock `gh`
-- Prefer a standalone binary if practical; Go plus `google/go-github` is the leading candidate
-- Define and document the supported subset plus unsupported GraphQL- or body-dependent flows
-- Start with existing/manual auth flows and leave tighter credential-path integration to later milestones
-
-**Out of scope:**
-- Full parity with stock `gh`
-- GraphQL-backed GitHub operations
-- Re-implementing every GitHub workflow behind one generic wrapper surface
-
-**Dependencies:** m14 (fine-grained proxy and repo/path-aware policy matching)
-
-### m16-proxy-secret-injection
+### m15-proxy-secret-injection
 
 Make the proxy the primary credential path for HTTP-native auth by keeping real secrets out of the agent container and injecting them into matched outbound requests.
 
 **Goals:**
-- Support placeholder-based secret substitution in outbound HTTP headers
+- Support direct matched-request credential injection for outbound HTTP headers
 - Keep raw secret values in a host-only source mounted into the proxy only
 - First supported rollout for git over HTTPS with repo-level scoping
 - Support other HTTP-native auth patterns such as env-token clients where practical
@@ -268,6 +248,26 @@ Make the proxy the primary credential path for HTTP-native auth by keeping real 
 - Replacing every credential flow with proxy injection
 
 **Dependencies:** m14 (request-phase MITM matching), m3 (proxy foundation)
+
+### m16-github-rest-wrapper
+
+Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
+URLs and can be constrained by `m14` policies.
+
+**Goals:**
+- Support a curated set of common, repo-scoped GitHub workflows using REST-only endpoints
+- Keep repo identity explicit in URL paths so single-repo allowlists are practical under `m14`
+- Prefer a thin wrapper over full parity with stock `gh`
+- Prefer a standalone binary if practical; Go plus `google/go-github` is the leading candidate
+- Define and document the supported subset plus unsupported GraphQL- or body-dependent flows
+- Use `m15` proxy-side credential injection where practical instead of storing GitHub tokens in the agent container
+
+**Out of scope:**
+- Full parity with stock `gh`
+- GraphQL-backed GitHub operations
+- Re-implementing every GitHub workflow behind one generic wrapper surface
+
+**Dependencies:** m14 (fine-grained proxy and repo/path-aware policy matching), m15 (primary HTTP credential path)
 
 ### m17-cli-monitoring
 
@@ -287,11 +287,11 @@ Add a narrower, secondary credential path for tools and auth flows that cannot b
 
 **Goals:**
 - Host-side credential helper bridge for clients that must obtain a credential locally
-- Support non-HTTP or helper-protocol-shaped auth workflows that `m16` cannot cover
+- Support non-HTTP or helper-protocol-shaped auth workflows that `m15` cannot cover
 - Keep credentials off disk inside the container even when the client must receive them
 - Integrate the helper lifecycle with the Go CLI
 
-**Dependencies:** m13 (Go CLI manages service lifecycle), m16 (primary proxy-based credential path defined first)
+**Dependencies:** m13 (Go CLI manages service lifecycle), m15 (primary proxy-based credential path defined first)
 
 ## Decisions
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,22 +111,23 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Domain-only rules remain backward-compatible and keep the CONNECT fast path
 - `agentbox proxy reload` and `agentbox edit policy` hot-reload policy changes with last-known-good fallback
 
-## m15: GitHub REST wrapper (planned)
+## m15: Proxy-side secret injection (planned)
+
+- Make proxy injection the primary mechanism for HTTP-native credentials
+- Store raw secret values in a host-only source and mount them into the proxy only
+- Inject headers directly on matched outbound requests with leak-detection guardrails
+- First rollout: git over HTTPS with repo-level scoping
+- Keep GitHub tokens out of the agent container for clone, fetch, and push over smart HTTP
+- Evaluate other HTTP-native clients after the GitHub Git flow is proven
+
+## m16: GitHub REST wrapper (planned)
 
 - Repo-scoped GitHub wrapper using REST-only endpoints
 - Keep repo identity visible in request URLs so m14 policies can constrain access to one repo
 - Support a curated set of high-value GitHub workflows that fit REST plus URL-based policy matching
 - Prefer a standalone binary if practical; Go plus `google/go-github` is the leading candidate
 - Define and document the supported subset and explicitly exclude GraphQL-dependent `gh` flows
-- Initial auth can reuse existing/manual token flows; tighter integration can come later
-
-## m16: Proxy-side secret injection (planned)
-
-- Make proxy injection the primary mechanism for HTTP-native credentials
-- Store raw secret values in a host-only source and mount them into the proxy only
-- Inject headers on matched outbound requests with leak-detection guardrails
-- First rollout: git over HTTPS with repo-level scoping
-- Evaluate env-token clients such as `gh` where placeholder substitution is sufficient
+- Use `m15` proxy-side credential injection where practical instead of storing GitHub tokens in the agent container
 
 ## m17: CLI monitoring and policy management (planned)
 

--- a/docs/upgrades/m14-request-aware-rules.md
+++ b/docs/upgrades/m14-request-aware-rules.md
@@ -113,5 +113,5 @@ A rejected reload emits `"action": "rejected"` with an `error` field and keeps t
   and body.
 - Request or response mutation.
 - Non-HTTP protocols.
-- GitHub REST wrapper work (tracked for `m15`).
-- Secret injection or credential features (tracked for `m16`).
+- Secret injection or credential features (tracked for `m15`).
+- GitHub REST wrapper work (tracked for `m16`).


### PR DESCRIPTION
## Summary

Reorder the upcoming credential and GitHub workflow milestones so proxy-side secret injection comes before the GitHub REST wrapper.

This makes `m15` the direct matched-request credential injection milestone, with GitHub smart HTTP as the first rollout, and moves the GitHub REST wrapper to `m16` so it can reuse the credential path instead of starting from manual token handling.

