### PR TITLE
Release m15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+Proxy-side credential injection from `m15`.
+
+### Added
+
+- **Proxy-side request header injection.** Policy can now attach `domains[].transform.request.headers` to matched rules so the proxy injects `Bearer` or `Basic` auth headers at request time, with `on_existing_header: fail` as the default fail-closed behavior.
+- **File-backed proxy secret source.** The proxy now resolves logical secret IDs from `${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}`, mounted read-only into the proxy as `/run/secrets/agentbox`. Secret files are read on demand, kept out of the agent container, and validated for path safety, file type, UTF-8 text, non-empty content, and newline handling.
+- **GitHub Git credential injection.** Repo-scoped GitHub service entries can now configure `git.access: read | readwrite` and `git.auth.secret` so clone, fetch, and push over smart HTTP receive proxy-injected credentials without storing real tokens in the agent container.
+- **Git askpass compatibility shim.** Authenticated GitHub Git entries can opt into `git.auth.client_shim.kind: git-askpass`, which gives Git deterministic fake credentials inside the agent container while the proxy replaces the outbound `Authorization` header with the real secret.
+- **Secret and credential docs.** Added `docs/secrets.md`, refreshed Git and policy schema docs, and added focused examples for private GitHub fetch, readwrite GitHub push, and explicit host-scoped request transforms.
+
+### Changed
+
+- **Managed compose files now mount secrets and credential shims.** The proxy receives the host secret directory with `bind.create_host_path: false`, and the agent receives only the generated credential-shim volume read-only.
+- **GitHub repo-scoped policy syntax now uses surface mappings.** `git` and `api` mappings replace the earlier `surfaces` list. Repo-scoped `surfaces`, top-level `access`, top-level `auth`, and repo-scoped `readonly` are rejected with targeted migration errors.
+- **Proxy logs now include query strings in request paths.** Decision, response, header-injection, and error logs include `?query` data so Git smart-HTTP discovery requests can be distinguished without cross-referencing `matched_rule_index`.
+
+### Fixed
+
+- **Credential shim reloads now update live shim files.** The proxy entrypoint exports `AGENTBOX_CREDENTIAL_SHIM_INIT_PATH`, so SIGHUP policy reloads can rewrite generated shim fragments instead of silently skipping them.
+- **Secret-file errors are clearer.** Empty secret files and files with extra trailing newlines now fail at the proxy with explicit messages instead of producing empty auth headers or generic invalid-byte errors.
+
 ## [0.14.0] - 2026-05-01
 
 Fine-grained proxy rules from `m14`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-21
+
 Proxy-side credential injection from `m15`.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The installer defaults to `~/.local/bin`. To choose a version or install directo
 
 ```bash
 curl -fsSL https://github.com/mattolson/agent-sandbox/releases/latest/download/install.sh | \
-  sh -s -- --version v0.14.0 --install-dir /usr/local/bin
+  sh -s -- --version v0.15.0 --install-dir /usr/local/bin
 ```
 
 For the full manual install process, see the [installation notes](docs/cli.md#manual-install).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 Run AI coding agents in a locked-down local sandbox with:
 
 - Minimal filesystem access (read/write access to only your repository directory)
-- Configurable network egress policy enforced by a sidecar proxy (restrict by hostname, as well as other attributes, like scheme, method, path, and query string)
+- Configurable network egress policy enforced by a sidecar proxy (restrict by hostname, as well as fine-grained attributes, like scheme, method, path, and query string)
+- Secret injection conducted in the proxy, so the agent container never sees secrets such as API keys
 - Iptables firewall preventing direct outbound (all traffic must go through the proxy)
 - Reproducible environments (Debian container with pinned dependencies)
 - Persistent volume for agent state - auth and config preserved across container restarts
@@ -160,6 +161,9 @@ The agent's iptables firewall (`init-firewall.sh`) blocks all direct outbound ex
 
 The proxy's CA certificate is shared via a Docker volume and automatically installed into the agent's system trust store at startup.
 
+For matched requests, policy can also tell the proxy to inject an HTTP header from a host-side secret file. The secret
+directory is mounted into the proxy only; the agent container sees neither the raw token nor the secret mount.
+
 ### Customizing the policy
 
 The network policy lives in your project in the `.agent-sandbox/policy/` directory.
@@ -205,7 +209,25 @@ services:
       access: read
 ```
 
-For a private repo that needs proxy-side credential injection, add `git.auth.secret` and (for `readwrite`) a `client_shim`. See [GitHub Git from inside the container](#github-git-from-inside-the-container) below.
+For a private repo that needs proxy-side credential injection, add `git.auth.secret`. For push access, use
+`git.access: readwrite` and add the `git-askpass` client shim so Git can run non-interactively while the proxy replaces
+the fake credential before the request reaches GitHub:
+
+```yaml
+services:
+  - name: github
+    merge_mode: replace
+    repos:
+      - owner/repo
+    git:
+      access: readwrite
+      auth:
+        secret: github.owner.repo.push-token
+        client_shim:
+          kind: git-askpass
+```
+
+See [GitHub Git from inside the container](#github-git-from-inside-the-container) below for the host-side secret setup.
 
 If you edit policy files directly, apply changes without restarting the proxy:
 
@@ -221,6 +243,19 @@ See [docs/policy/schema.md](./docs/policy/schema.md) for the full policy format 
 ### GitHub Git from inside the container
 
 The recommended way to clone, fetch, or push private GitHub repos from inside the container is to let the proxy inject the credential. The token lives in a host-side secret directory, never in the container's filesystem or Docker volumes.
+
+Create the secret directory on the host before starting the sandbox:
+
+```bash
+mkdir -p "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"
+chmod 700 "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"
+printf '%s' "ghp_examplevalue" \
+  > "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}/github.owner.repo.push-token"
+chmod 600 "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}/github.owner.repo.push-token"
+```
+
+After changing policy, run `agentbox proxy reload`. If the policy uses `client_shim`, open a new `agentbox exec` shell
+so Git sees the generated askpass environment.
 
 - [docs/git.md](./docs/git.md) - end-to-end setup for read-only and readwrite Git flows
 - [docs/secrets.md](./docs/secrets.md) - host secret directory layout, permissions, freshness, and non-goals
@@ -243,6 +278,7 @@ Key principles:
 
 - Minimal mounts: only the repo workspace + project-scoped agent state
 - Network egress is tightly controlled through sidecar proxy with default deny policy
+- Raw proxy-injected secrets are mounted into the proxy only, not the agent container
 - Firewall verification runs at every container start
 
 ### Git credentials

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -230,7 +230,7 @@ filtering.
 - SIGHUP-based policy hot reload through `agentbox proxy reload` and `agentbox edit policy`
 - Schema docs, examples, troubleshooting guidance, and proxy integration coverage
 
-### m15-proxy-secret-injection
+### m15-proxy-secret-injection (done)
 
 Make the proxy the primary credential path for HTTP-native auth by keeping real secrets out of the agent container and injecting them into matched outbound requests.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,7 +111,7 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Domain-only rules remain backward-compatible and keep the CONNECT fast path
 - `agentbox proxy reload` and `agentbox edit policy` hot-reload policy changes with last-known-good fallback
 
-## m15: Proxy-side secret injection (planned)
+## m15: Proxy-side secret injection (done)
 
 - Make proxy injection the primary mechanism for HTTP-native credentials
 - Store raw secret values in a host-only source and mount them into the proxy only

--- a/scripts/install-agentbox.sh
+++ b/scripts/install-agentbox.sh
@@ -14,7 +14,7 @@ Defaults:
 
 Examples:
   sh install-agentbox.sh
-  sh install-agentbox.sh --version v0.14.0
+  sh install-agentbox.sh --version v0.15.0
   sh install-agentbox.sh --install-dir /usr/local/bin
 EOF
 }


### PR DESCRIPTION
## Summary

Prepare the `v0.15.0` release docs for M15 proxy-side credential injection.

This PR updates the changelog, README, roadmap, and install-script examples so the release branch reflects the M15 feature set:

- Proxy-side request header injection for matched policy rules.
- File-backed proxy secrets mounted into the proxy only.
- GitHub Git credential injection with repo-scoped `git.access` and `git.auth.secret`.
- Optional `git-askpass` compatibility shim for push flows.
- README setup guidance for host secret provisioning and GitHub Git policy.
- M15 roadmap/project status marked as done.
- Version examples updated from `v0.14.0` to `v0.15.0`.
