### PR TITLE
Add m16 plan

### DIFF
--- a/.agent-sandbox/compose/agent.claude.yml
+++ b/.agent-sandbox/compose/agent.claude.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=claude
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-claude@sha256:a9ed8dfa43797dc77ca926dfd3662b7bbf7cfa1f913f048a7a89f10799265ad1
+    image: ghcr.io/mattolson/agent-sandbox-claude@sha256:09182e0bb1744a52df1f0ab2ad6b0d2971d09291b45117a53377b810612b5eae
     volumes:
       - claude-state:/home/dev/.claude
       - claude-history:/commandhistory

--- a/.agent-sandbox/compose/agent.codex.yml
+++ b/.agent-sandbox/compose/agent.codex.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=codex
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-codex@sha256:406153a6cf991ff6289f968b4f095c0cea3ea988717ff9291f8b93b9b29accd5
+    image: ghcr.io/mattolson/agent-sandbox-codex@sha256:35c232cecf76f7f5b873b7af9cd7f680c19d7c7b86b5f6ec71214387f22fba12
     volumes:
       - codex-state:/home/dev/.codex
       - codex-history:/commandhistory

--- a/.agent-sandbox/compose/agent.gemini.yml
+++ b/.agent-sandbox/compose/agent.gemini.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=gemini
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-gemini@sha256:562a283cc11164415c476414607ec302ac9f69770cfad84b927fc90b5e96e85a
+    image: ghcr.io/mattolson/agent-sandbox-gemini@sha256:8b46ef632ec42f218f86b6dd8650a00012d4fe411471fcaaa6324fe9706105af
     volumes:
       - gemini-state:/home/dev/.gemini
       - gemini-history:/commandhistory

--- a/.agent-sandbox/compose/agent.opencode.yml
+++ b/.agent-sandbox/compose/agent.opencode.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - AGENTBOX_ACTIVE_AGENT=opencode
   agent:
-    image: ghcr.io/mattolson/agent-sandbox-opencode@sha256:a7d208d4baa932844cca4b49fc135a9ee7248a0ad75f3a9cb629c1de67c08895
+    image: ghcr.io/mattolson/agent-sandbox-opencode@sha256:31d6f03874a6f71ae93dd2c9afc4e89697d884cd98309029aac939b8bfe4e9b2
     volumes:
       - opencode-config:/home/dev/.config
       - opencode-local-share:/home/dev/.local/share

--- a/.agent-sandbox/compose/base.yml
+++ b/.agent-sandbox/compose/base.yml
@@ -4,7 +4,7 @@
 name: agent-sandbox
 services:
   proxy:
-    image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:7c13a98060e0bf4d0c3587a4be27f0eb1bab62bebd56e08499c4f10aad4f1928
+    image: ghcr.io/mattolson/agent-sandbox-proxy@sha256:05220196365213943f81116ae6e727bc54a48d3f302b8cbee9e49cb3bb7f62c6
     cap_drop:
       - ALL
     volumes:

--- a/docs/plan/decisions/006-credential-shim-is-renderer-owned.md
+++ b/docs/plan/decisions/006-credential-shim-is-renderer-owned.md
@@ -80,9 +80,8 @@ read only at request time inside the proxy.
 
 - The shim-and-replace pairing cannot be partially configured. Either both halves are present
   in the rendered policy or neither.
-- Future credential-injection work (REST APIs in `m16`, host credential helpers in `m18`) can
-  define new shim kinds without adopting a generic env-export surface that would be hard to
-  constrain.
+- Future credential-injection work (provider API keys in `m16`, GitHub REST APIs in `m17`, and host credential helpers
+  in `m19`) can define new shim kinds without adopting a generic env-export surface that would be hard to constrain.
 - Rendered policy stays small. The `credential_shim` block only appears when something needs
   it, and the payload's only consumer is `/etc/agent-sandbox/shell-init.sh`.
 

--- a/docs/plan/milestones/m13-go-cli-rewrite/milestone.md
+++ b/docs/plan/milestones/m13-go-cli-rewrite/milestone.md
@@ -19,7 +19,7 @@ legacy Bash CLI, parity harness, and Docker CLI image distribution were removed 
 - Documentation and release workflow updates that make the Go binary the primary installation path
 
 **Excluded:**
-- New CLI features from later milestones (`m14` through `m18`)
+- New CLI features from later milestones (`m14` and later)
 - Changes to the layered runtime ownership model or proxy policy format
 - Windows support
 - Replacing the proxy-side `render-policy` helper with a separate host-side policy merge implementation
@@ -74,11 +74,12 @@ The Go rewrite should live beside the Bash CLI until the final cutover. `cli/` r
 
 ## Future TUI Compatibility
 
-`m13` should future-proof the CLI for `m17`, but it should not choose the `m17` UI architecture prematurely.
+`m13` should future-proof the CLI for the later monitoring milestone, but it should not choose that UI architecture prematurely.
 
 - Cobra helps as a command entrypoint for future interactive subcommands, but it is not itself a TUI framework.
 - The Go rewrite should keep Cobra handlers thin and move runtime, policy, logging, and unblock logic into reusable internal packages that can back both standard CLI commands and a future TUI.
-- `m17` should choose its TUI framework independently during milestone planning once the monitoring workflow is better defined.
+- The monitoring milestone should choose its TUI framework independently during milestone planning once the workflow is
+  better defined.
 - `Bubble Tea` is the most likely default choice for a future full-screen TUI, but that remains a likely direction rather than an `m13` commitment.
 
 ## Tasks
@@ -266,4 +267,5 @@ Documented that the Go rewrite will live under `cmd/`, `internal/`, `testdata/`,
 
 ### 2026-03-28: Added future TUI note
 
-Documented that m13 should keep core logic reusable for a future m17 interactive TUI, while deferring framework selection to m17 planning with Bubble Tea noted as the likely default.
+Documented that m13 should keep core logic reusable for a future interactive TUI, while deferring framework selection to
+the monitoring milestone planning with Bubble Tea noted as the likely default.

--- a/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
@@ -22,8 +22,8 @@ request-aware rules, semantic GitHub service expansion, hot reload, integration 
 
 **Excluded:**
 - Secret injection, header substitution, or other credential features from `m15`
-- GitHub REST wrapper work from `m16`
-- Monitoring UI or interactive unblock workflows from `m17`
+- GitHub REST wrapper work from `m17`
+- Monitoring UI or interactive unblock workflows from `m18`
 - Non-HTTP protocols
 - Header matching and request body inspection. For now, a matched URL rule implies the endpoint is trusted to receive
   the full request.

--- a/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/execution-log.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/execution-log.md
@@ -166,7 +166,7 @@ expanded fragments participate in the existing host-record merge path.
 ## 2026-04-16 15:12 UTC - Drafted the task plan and locked the intended boundary
 
 Reviewed the `m14` milestone plan, project learnings, decision record `005`, the current `render-policy`
-implementation, the `m14.2` matcher boundary, and the downstream `m16` GitHub wrapper goals. The main planning
+implementation, the `m14.2` matcher boundary, and the downstream `m17` GitHub wrapper goals. The main planning
 conclusion is that `m14.3` should not push GitHub-specific behavior into the matcher. Service semantics belong at
 render time and should compile into the same canonical host-record IR that authored `domains` already use.
 

--- a/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/task.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/task.md
@@ -182,7 +182,7 @@ For GitHub `git`, the intended `readonly` mapping is:
 That keeps clone and fetch working under `readonly: true` while still excluding push.
 
 That is enough to keep repo-scoped Git transport visible in the URL path and to support `m15` credential injection
-without quietly broadening the host allowlist. `m16` remains about the higher-level REST wrapper surface; adding Git
+without quietly broadening the host allowlist. `m17` remains about the higher-level REST wrapper surface; adding Git
 smart-HTTP to `m14.3` does not replace that milestone.
 
 #### Merge And Override Semantics
@@ -353,5 +353,5 @@ Test runs after the simplify pass:
 - If future services duplicate the pattern of "named surfaces plus scoped selectors," revisit whether the per-service
   Python expander can be factored into a shared helper; `m14.3` deliberately resisted that abstraction until a second
   rich service exists.
-- Downstream `m16` still owns the GitHub REST wrapper work; the repo-scoped `api` surface added here intentionally
+- Downstream `m17` still owns the GitHub REST wrapper work; the repo-scoped `api` surface added here intentionally
   stops at URL-shape filtering. Credential-aware behavior belongs to `m15`.

--- a/docs/plan/milestones/m15-proxy-secret-injection/milestone.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/milestone.md
@@ -35,11 +35,12 @@ to hold the real secret.
 - Request body mutation
 - Request, response, header, or URL scanning for leaked secret values
 - Replacing every credential flow with proxy injection
-- A full host credential helper service; that remains `m18`
+- A full host credential helper service; that remains `m19`
 - macOS Keychain-backed secret resolution; m15 should preserve the extension point but ship file-backed storage first
 - A complete secret-management CLI with project, target, and session scoped storage
 - A new live-update control plane beyond the existing policy reload path
-- GitHub REST wrapper work; that moves to `m16`
+- Provider API-key injection; that moves to `m16`
+- GitHub REST wrapper work; that moves to `m17`
 
 ## Design
 

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/execution-log.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/execution-log.md
@@ -71,8 +71,8 @@ with surface-scoped GitHub mappings. The preferred policy shape is now `git.acce
 `readonly` for unauthenticated GitHub repo-scoped policies, but that compatibility path was removed after confirming the
 syntax had not shipped.
 
-**Decision:** `api.auth` is reserved and rejected in m15.5. GitHub REST wrapper and API credential behavior belongs to
-`m16`.
+**Decision:** `api.auth` is reserved and rejected in m15.5. Provider API-key behavior belongs to `m16`, and GitHub REST
+wrapper behavior belongs to `m17`.
 
 ## 2026-05-07 04:00 UTC - Initial task plan
 

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/task.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/task.md
@@ -146,8 +146,8 @@ services:
         secret: github.agent-sandbox.push-token
 ```
 
-Reject `api.auth` for now with a clear reserved/unsupported error. GitHub REST wrapper behavior belongs to `m16`, and
-M15.5 should not imply API credential injection.
+Reject `api.auth` for now with a clear reserved/unsupported error. Provider API-key injection belongs to `m16`, GitHub
+REST wrapper behavior belongs to `m17`, and M15.5 should not imply API credential injection.
 
 For authenticated Git rules, emit the same canonical rule-scoped transform shape as explicit `domains[].transform`
 authoring:

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.6-client-compatibility-shim/task.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.6-client-compatibility-shim/task.md
@@ -215,8 +215,9 @@ should still prove:
   env-token system needs a concrete provider target and should not be smuggled into GitHub Git work.
 - Resolved for this plan: direct GitHub smart-HTTP auth remains the default and keeps `on_existing_header: fail`.
   `client_shim` is opt-in because replacement weakens the existing-header guardrail.
-- Resolved for this plan: m15.6 does not implement GitHub REST auth or stock `gh` support. M16 owns the REST wrapper
-  direction, and M18 owns residual real credential-helper delivery.
+- Resolved for this plan: m15.6 does not implement provider API-key auth, GitHub REST auth, or stock `gh` support. M16
+  owns provider API-key injection, M17 owns the REST wrapper direction, and M19 owns residual real credential-helper
+  delivery.
 - Resolved in implementation: source the generated environment from zsh shell initialization only. Direct
   `agentbox exec <command>` invocations that bypass zsh remain a documented follow-up rather than changing exec
   quoting or environment semantics in this task.

--- a/docs/plan/milestones/m16-provider-api-key-injection/milestone.md
+++ b/docs/plan/milestones/m16-provider-api-key-injection/milestone.md
@@ -1,0 +1,229 @@
+# Milestone: m16 - Provider API-Key Injection
+
+## Goal
+
+Extend the `m15` proxy-side credential model from GitHub Git auth to model-provider API-key traffic, so supported agents
+can call OpenAI, Anthropic, and Gemini-style APIs without the real API key being readable inside the agent container.
+
+This milestone should make provider API-key injection a first-class, documented path for current agents that support
+API-key auth, while keeping OAuth, device-code, and local credential-helper flows out of this layer.
+
+## Scope
+
+Included:
+
+- Provider API-key injection for OpenAI, Anthropic, and Gemini API request patterns
+- A generic raw-header secret transform for headers whose value is the secret itself
+- Service-catalog-owned provider auth expansion, rather than hand-authored request transforms in examples
+- A generic renderer-owned env-var shim primitive for catalog-owned client compatibility hints, first used for
+  `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY`
+- Integration coverage for Codex, Claude API-key mode, Gemini API-key mode, and provider-backed Pi/OpenCode flows where
+  they use supported providers
+- Documentation and examples that distinguish proxy-injected API-key flows from OAuth/login flows
+
+Excluded:
+
+- Copilot and Factory primary auth, unless a concrete API-key flow is identified during discovery
+- OAuth, browser login, device-code, refresh-token, and subscription-login flows
+- Request-body mutation, response mutation, or scanning for leaked secret values
+- Local delivery of real credentials into the agent container; residual cases stay with `m19-host-credential-service`
+- Arbitrary user-authored env exports that are not paired with catalog-owned proxy replacement rules
+- Clients that copy env credentials into query strings, request bodies, signatures, or local auth stores in a way the
+  proxy cannot safely replace
+- Broad provider abstraction across every Models.dev or AI SDK provider
+- A full `agentbox secrets` management CLI
+
+## Applicable Learnings
+
+- Service auth semantics belong in the catalog, not the matcher or enforcer. The matcher should continue consuming
+  canonical host/rule/transform IR.
+- Request transforms must force request inspection at CONNECT time for HTTPS, even when no method/path/query rule is
+  otherwise required.
+- Header injection should stage all rendered values before mutating a request, so failures block cleanly without partial
+  mutation.
+- Renderer-owned shim metadata is the right boundary when an agent-visible fake credential must be paired with proxy
+  replacement rules.
+- A generic compatibility primitive is useful, but it must not become a generic authoring escape hatch. Known catalog
+  entries should request the shim and the matching replacement rules together.
+- User-facing examples should be backed by integration tests so documented policy shapes do not drift from renderer
+  behavior.
+- Proxy-side injection does not protect a secret that the user also stores in an agent volume, env var, project file, or
+  provider-specific auth file.
+
+## Tasks
+
+### m16.1-provider-auth-discovery-and-schema
+
+**Summary:** Confirm provider request shapes and define the authored service schema for API-key injection.
+
+**Scope:**
+- Verify the current auth headers and env-var conventions for OpenAI, Anthropic, and Gemini
+- Identify which current agents can plausibly use provider API-key mode through env vars or config
+- Decide the rich service authoring shape for provider auth, including `auth.secret` and optional `client_shim`
+- Define the generic rendered env-shim IR separately from the service-specific authored shape
+- Decide whether Gemini supports only `GEMINI_API_KEY` first, or also `GOOGLE_API_KEY`
+- Exclude OAuth/login flows from the schema
+
+**Acceptance Criteria:**
+- The milestone has a concrete YAML authoring shape for each supported provider service
+- The rendered env-shim shape can support future catalog-owned env-token clients without exposing arbitrary env exports
+- Unsupported auth modes are documented explicitly
+- The design names which supported agents are expected to work in the first rollout
+
+**Dependencies:** m15 proxy-side secret injection
+
+**Risks:** Agent CLIs may validate API-key formats before making network requests, which could make a simple fake env var
+insufficient for some clients.
+
+### m16.2-raw-header-transform
+
+**Summary:** Add a generic transform that injects the resolved secret as the complete header value.
+
+**Scope:**
+- Add a `raw` request-header transform alongside existing `bearer` and `basic`
+- Preserve existing validation and redaction behavior
+- Keep `on_existing_header: fail` as the default
+- Add unit and integration coverage for raw header injection and failure paths
+
+**Acceptance Criteria:**
+- A policy rule can inject `x-api-key: <secret>` or `x-goog-api-key: <secret>` without custom provider code in the
+  enforcer
+- Logs show secret IDs and transform type but never resolved values
+- Existing `bearer` and `basic` tests continue to pass
+
+**Dependencies:** None beyond m15
+
+**Risks:** A too-specific transform name could leak provider assumptions into the generic injection layer. Keep this
+strictly header-value-oriented.
+
+### m16.3-provider-service-catalog-auth
+
+**Summary:** Teach the service catalog to emit provider-specific request rules and header transforms.
+
+**Scope:**
+- Add rich auth mappings for the existing `claude`, `codex`, and `gemini` services
+- Emit `Authorization: Bearer <secret>` for OpenAI-compatible API calls
+- Emit `x-api-key: <secret>` for Anthropic API calls
+- Emit `x-goog-api-key: <secret>` for Gemini API calls
+- Keep broad host-only service entries backward-compatible when no auth mapping is present
+- Keep provider semantics in `service_catalog.py`; do not add provider branches to the matcher or enforcer
+
+**Acceptance Criteria:**
+- Authenticated provider service entries render into canonical host records with rule-scoped transforms
+- Unauthenticated service entries preserve current behavior
+- Renderer tests reject unsupported auth keys and malformed secret IDs
+
+**Dependencies:** `m16.1`, `m16.2`
+
+**Risks:** Existing simple service names have broad host expansion. Adding auth must not accidentally inject credentials
+into unrelated login, telemetry, documentation, or update hosts.
+
+### m16.4-generic-env-credential-shim
+
+**Summary:** Build a generic renderer-owned env-var shim primitive and wire provider API-key uses through the catalog.
+
+**Scope:**
+- Extend rendered shim metadata beyond Git askpass while keeping it renderer-owned and kinded
+- Support a generic `env` shim kind that can emit deterministic fake env values for catalog-selected variable names
+- Pair each env shim emission with `on_existing_header: replace` on the matching provider rules
+- Keep authored policy service-specific, for example `auth.client_shim.kind: env`, rather than letting users provide
+  arbitrary env var names
+- Source the generated env exports through the existing shell init path
+- Keep the primitive reusable for later catalog-owned env-token clients that map fake env values to replaceable request
+  headers
+
+**Acceptance Criteria:**
+- A service entry can opt into a known env shim without exposing the real secret
+- The proxy replaces a fake client-generated auth header with the real header before upstream delivery
+- Authored policy cannot name arbitrary env vars or emit env shims without matching proxy replacement rules
+- The rendered shim metadata is generic enough to cover future catalog-owned env-token clients without changing the
+  shell-init consumer contract
+- Authored top-level shim metadata remains rejected
+
+**Dependencies:** `m16.3`
+
+**Risks:** Some clients may inspect key prefixes, copy the fake value into a query string or request body, or use the env
+value to sign requests before making a replaceable HTTP request. Those clients may need a provider-specific shim or may
+remain out of scope.
+
+### m16.5-agent-flow-integration
+
+**Summary:** Wire and document the supported first-rollout agent flows.
+
+**Scope:**
+- Validate the flow for Codex with OpenAI API-key auth
+- Validate the flow for Claude Code API-key mode when using Anthropic API credentials
+- Validate the flow for Gemini CLI API-key mode
+- Validate provider-backed Pi and OpenCode flows where they use OpenAI, Anthropic, or Gemini
+- Document that Copilot and Factory remain OAuth/login-based unless a supported API-key path is found
+
+**Acceptance Criteria:**
+- Each supported flow has a policy example and setup notes
+- Each unsupported flow has a clear explanation instead of a silent omission
+- Agent docs no longer recommend putting real supported provider API keys inside the container as the primary path
+
+**Dependencies:** `m16.4`
+
+**Risks:** Live-provider validation can be hard to run in CI. Prefer mocked proxy integration tests plus documented manual
+smoke checks.
+
+### m16.6-docs-examples-and-tests
+
+**Summary:** Add end-user docs, policy examples, and regression coverage for the full provider API-key injection path.
+
+**Scope:**
+- Update `docs/secrets.md`, `docs/policy/schema.md`, agent docs, README, and troubleshooting guidance
+- Add examples for OpenAI, Anthropic, and Gemini provider auth
+- Add integration tests that prove fake env-derived headers are replaced and real secrets are redacted
+- Add failure-mode tests for missing secrets, existing headers, unsupported auth shapes, and unsafe secret permissions
+
+**Acceptance Criteria:**
+- Documentation shows the recommended host-secret setup and policy shape for each supported provider
+- Tests exercise the examples or share fixtures with them
+- Proxy logs remain useful without leaking secret material
+
+**Dependencies:** `m16.2`, `m16.3`, `m16.4`
+
+**Risks:** Duplicating grammar details across docs can drift. Keep `docs/policy/schema.md` canonical and link to it from
+agent-specific pages.
+
+## Execution Order
+
+1. Start with `m16.1` to lock the provider surface and avoid implementing a schema around guessed client behavior.
+2. Implement `m16.2` early because Anthropic and Gemini need raw API-key headers.
+3. Add catalog auth in `m16.3`.
+4. Add the generic env shim primitive in `m16.4` only after the catalog owns the provider auth rules it pairs with.
+5. Validate and document agent flows in `m16.5`.
+6. Finish with the docs, examples, and regression sweep in `m16.6`.
+
+`m16.2` can proceed in parallel with part of `m16.1` once the raw-header need is confirmed. `m16.5` should not start until
+the shim behavior exists.
+
+## Risks
+
+- Agent CLIs may reject placeholder values before any HTTP request reaches the proxy.
+- Provider clients may send credentials through headers, query strings, or provider-specific SDK internals that differ by
+  version.
+- A fake env var can be safe for replaceable header auth and unsafe for query-string, body, signature, or local-store
+  auth. The plan should prove each catalog-owned use case instead of assuming env-token clients are equivalent.
+- Broad provider host allowlists could send a powerful API key to a wider URL surface than intended.
+- Users may already have real keys in persisted agent volumes; docs need to distinguish migration from fresh setup.
+- OAuth-based agents will still need a different credential story, so this milestone must not overclaim "all auth".
+
+## Definition of Done
+
+- Provider API-key injection works for OpenAI, Anthropic, and Gemini request patterns without real keys in the agent
+  container.
+- Codex, Claude API-key mode, Gemini API-key mode, and provider-backed Pi/OpenCode flows have documented supported paths
+  where applicable.
+- Unsupported OAuth/login flows are explicitly called out and deferred to later credential-helper work.
+- The policy schema, examples, and tests cover raw header injection, provider catalog auth, the generic env shim
+  primitive, redaction, and fail-closed behavior.
+- The roadmap treats GitHub REST wrapper, CLI monitoring, and host credential service as later milestones.
+
+## Changes
+
+### 2026-05-23: Created After m15
+
+Inserted this milestone before the GitHub REST wrapper because provider API-key injection is the more direct extension
+of `m15` and benefits more current agent workflows.

--- a/docs/plan/milestones/m17-github-rest-wrapper/milestone.md
+++ b/docs/plan/milestones/m17-github-rest-wrapper/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m16 - GitHub REST Wrapper
+# Milestone: m17 - GitHub REST Wrapper
 
 Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
 URLs and can be constrained by `m14` policies. The goal is not to replace stock `gh` wholesale; it is to provide a
@@ -76,7 +76,7 @@ This milestone should not invent a second credential path. It should use `m15` p
 the wrapper's REST calls can be matched safely by host, method, and path. Residual flows that require the client to
 receive credential material belong in later helper work:
 
-- `m18` for residual helper-based flows
+- `m19` for residual helper-based flows
 
 ### Distribution
 
@@ -92,7 +92,7 @@ This milestone may later become its own open-source project. The current rationa
 an obvious standalone-binary equivalent to `gh` that intentionally stays on REST-only endpoints for use in constrained
 environments with network proxy inspection.
 
-That project-boundary decision is deferred for now. `m16` should proceed in a way that keeps extraction feasible later:
+That project-boundary decision is deferred for now. `m17` should proceed in a way that keeps extraction feasible later:
 
 - keep the wrapper surface narrow and well documented
 - avoid coupling the command surface too tightly to Agent Sandbox internals

--- a/docs/plan/milestones/m19-host-credential-service/milestone.md
+++ b/docs/plan/milestones/m19-host-credential-service/milestone.md
@@ -1,4 +1,4 @@
-# m18: Host Credential Service
+# Milestone: m19 - Host Credential Service
 
 Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m15-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
 

--- a/docs/plan/milestones/m6-cli/milestone.md
+++ b/docs/plan/milestones/m6-cli/milestone.md
@@ -25,7 +25,7 @@ Give developers a single command-line tool that handles the full lifecycle of an
 **Excluded:**
 - Go rewrite (m13)
 - Fine-grained proxy rules (m14)
-- Interactive monitoring/unblocking (m17)
+- Interactive monitoring/unblocking (now tracked for m18)
 
 ## Applicable Learnings
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -255,7 +255,32 @@ Make the proxy the primary credential path for HTTP-native auth by keeping real 
 
 **Dependencies:** m14 (request-phase MITM matching), m3 (proxy foundation)
 
-### m16-github-rest-wrapper
+### m16-provider-api-key-injection
+
+Extend the `m15` proxy-side credential model from GitHub Git auth to model-provider API-key traffic, so current agents
+can call supported provider APIs without the real API key being readable inside the agent container.
+
+**Goals:**
+- Add a generic raw-header transform for provider headers whose value is the secret itself
+- Add service-catalog-owned auth expansion for OpenAI, Anthropic, and Gemini provider API patterns
+- Support a generic renderer-owned fake env-var shim primitive, first used for clients that require `OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY` before making requests
+- Cover Codex, Claude API-key mode, Gemini API-key mode, and provider-backed Pi/OpenCode flows where they use supported
+  providers
+- Keep OAuth, browser login, device-code, subscription-login, and local credential-helper flows out of this layer
+- Document supported and unsupported agent/provider combinations clearly
+
+**Out of scope:**
+- Copilot and Factory primary auth unless a concrete API-key flow is identified during discovery
+- OAuth, device-code, refresh-token, and browser-login flows
+- Request-body mutation, response mutation, or scanning for leaked secret values
+- Local delivery of real credentials into the agent container
+- Arbitrary user-authored env exports that are not paired with catalog-owned proxy replacement rules
+- Broad provider support beyond OpenAI, Anthropic, and Gemini
+
+**Dependencies:** m15 (proxy-side secret injection), m14 (request-phase matching and transforms)
+
+### m17-github-rest-wrapper
 
 Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
 URLs and can be constrained by `m14` policies.
@@ -275,7 +300,7 @@ URLs and can be constrained by `m14` policies.
 
 **Dependencies:** m14 (fine-grained proxy and repo/path-aware policy matching), m15 (primary HTTP credential path)
 
-### m17-cli-monitoring
+### m18-cli-monitoring
 
 CLI tools for monitoring proxy activity and managing policy interactively.
 
@@ -287,7 +312,7 @@ CLI tools for monitoring proxy activity and managing policy interactively.
 
 **Dependencies:** m13 (Go CLI), m14 (fine-grained proxy and hot reload)
 
-### m18-host-credential-service
+### m19-host-credential-service
 
 Add a narrower, secondary credential path for tools and auth flows that cannot be handled cleanly by proxy-side injection.
 

--- a/docs/plan/research/alternatives.md
+++ b/docs/plan/research/alternatives.md
@@ -1222,7 +1222,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - The WireGuard plus shared-namespace design adds startup ordering and networking complexity without solving the separate IDE control plane that the repo itself documents
   - The packaged workflow is devcontainer- and Claude-shaped, not a neutral multi-agent control plane
 - Open questions:
-  - Could proxy-side secret substitution cover enough of `m18-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
+  - Could proxy-side secret substitution cover enough of `m19-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
   - Do we need transparent capture enough to justify the added WireGuard complexity, given the current explicit proxy plus firewall design already blocks direct egress?
   - Should any sandcat-inspired work land as devcontainer-only hardening rather than as part of the core backend contract?
 - Verdict: `useful supporting reference`
@@ -1314,7 +1314,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - Remote execution or gateway fleet support: no
 - Key strengths:
   - This is a genuine stronger-isolation reference, not just a container-plus-proxy variant
-  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m20-backend-interface`
+  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m21-backend-interface`
   - Network policy is materially richer than our current baseline: host allow-listing, path and method matching, request or response mutation, runtime allow-list edits, and offline mode
   - The VFS layer is more interesting than it first appears; it creates a host-side place to enforce or observe filesystem operations without bind-mounting the host repo directly into the guest
   - Lifecycle persistence and reconciliation are stronger than most research repos in this space
@@ -1335,7 +1335,7 @@ When reviewing an item, capture whether it implements any of these primitives:
 
 - Worth bringing into the vision:
   - a real microVM-backed stronger-isolation backend candidate
-  - host-side VFS and exec control-plane separation as input to `m20-backend-interface`
+  - host-side VFS and exec control-plane separation as input to `m21-backend-interface`
   - richer HTTP policy concepts for `m14`, especially method and path matching plus response shaping
   - lifecycle persistence and explicit garbage-collection or reconcile workflows for leaked sandbox resources
 - Probably not worth bringing in as-is:
@@ -1344,7 +1344,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - assuming a FUSE or VFS workspace model is the right default for local developer ergonomics before measuring it against a shared mount model
 - Research consequence:
   - Treat `matchlock` as a leading reference for the optional stronger-isolation backend and for backend-interface design, not as an argument to replace the current local default before we have comparative measurements
-  - It should directly inform `m20-backend-interface` and `m22-runtime-spikes-vm`
+  - It should directly inform `m21-backend-interface` and `m23-runtime-spikes-vm`
 
 ### strongdm/leash
 
@@ -1444,7 +1444,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - accepting materially different network semantics on macOS and Linux under one policy name without very clear degradation rules
 - Research consequence:
   - Treat `leash` as a leading reference for policy IR, rollout modes, and observability, not as proof that a container boundary alone is sufficient for the project's stronger-isolation backend
-  - It should inform `m19-capability-model` and `m20-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
+  - It should inform `m20-capability-model` and `m21-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
 
 ## Research backlog: commercial products
 
@@ -1644,15 +1644,15 @@ Deliverable:
 
 ## Proposed milestones
 
-### m19-capability-model
+### m20-capability-model
 
 Define the threat model, capability matrix, and backend scorecard.
 
-### m20-backend-interface
+### m21-backend-interface
 
 Define a backend-agnostic runner contract, event schema, and policy compiler boundary.
 
-### m21-runtime-spikes-lite
+### m22-runtime-spikes-lite
 
 Build and compare:
 
@@ -1660,21 +1660,21 @@ Build and compare:
 - OS-native backend
 - gVisor backend
 
-### m22-runtime-spikes-vm
+### m23-runtime-spikes-vm
 
 Build and compare:
 
 - Kata backend
 - One heavy-isolation backend such as Firecracker or full VM
 
-### m23-kubernetes-track
+### m24-kubernetes-track
 
 Only if earlier milestones justify it:
 
 - KubeVirt or Kata on Kubernetes
 - Cilium or similar for L7 policy and observability experiments
 
-### m24-decision-and-integration
+### m25-decision-and-integration
 
 Choose:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,7 +120,17 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Keep GitHub tokens out of the agent container for clone, fetch, and push over smart HTTP
 - Evaluate other HTTP-native clients after the GitHub Git flow is proven
 
-## m16: GitHub REST wrapper (planned)
+## m16: Provider API-key injection (planned)
+
+- Extend proxy-side secret injection from GitHub Git auth to model-provider API-key traffic
+- Add raw-header injection for provider headers whose value is the secret itself
+- Add service-catalog auth expansion for OpenAI, Anthropic, and Gemini API patterns
+- Add a generic renderer-owned fake env shim primitive, first used for clients that require `OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`
+- Support Codex, Claude API-key mode, Gemini API-key mode, and provider-backed Pi/OpenCode flows where practical
+- Explicitly exclude OAuth, browser login, device-code, subscription-login, and helper-protocol flows
+
+## m17: GitHub REST wrapper (planned)
 
 - Repo-scoped GitHub wrapper using REST-only endpoints
 - Keep repo identity visible in request URLs so m14 policies can constrain access to one repo
@@ -129,14 +139,14 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Define and document the supported subset and explicitly exclude GraphQL-dependent `gh` flows
 - Use `m15` proxy-side credential injection where practical instead of storing GitHub tokens in the agent container
 
-## m17: CLI monitoring and policy management (planned)
+## m18: CLI monitoring and policy management (planned)
 
 - Filtered log view for blocked requests
 - Interactive unblock workflow
 - Integration with hot reload for immediate policy updates
 - UI approach TBD (filtered stream, TUI, or hybrid)
 
-## m18: Host credential service (planned)
+## m19: Host credential service (planned)
 
 - Secondary credential path for flows that cannot be handled by proxy injection
 - Host-side service bridging container to native credential store or helper backend

--- a/docs/upgrades/m14-request-aware-rules.md
+++ b/docs/upgrades/m14-request-aware-rules.md
@@ -114,4 +114,4 @@ A rejected reload emits `"action": "rejected"` with an `error` field and keeps t
 - Request or response mutation.
 - Non-HTTP protocols.
 - Secret injection or credential features (tracked for `m15`).
-- GitHub REST wrapper work (tracked for `m16`).
+- GitHub REST wrapper work (tracked for `m17`).


### PR DESCRIPTION
## Summary

- Add a new `m16-provider-api-key-injection` milestone plan that extends proxy-side secret injection to OpenAI, Anthropic, and Gemini API-key flows.
- Define a generic renderer-owned env-var shim primitive, with provider API keys as the first catalog-owned use case.
- Shift the existing roadmap forward: GitHub REST wrapper to m17, CLI monitoring to m18, and host credential service to m19.
- Update related planning references so later credential-helper and runtime research milestones no longer conflict with the new m16/m19 numbering.

## Notes

The new m16 plan keeps the env shim generic as an implementation primitive, but not as an arbitrary user-authored env export surface. Catalog entries must pair any fake env value with matching proxy replacement rules.