### PR TITLE
Add milestone for hermes

### DIFF
--- a/docs/plan/decisions/006-credential-shim-is-renderer-owned.md
+++ b/docs/plan/decisions/006-credential-shim-is-renderer-owned.md
@@ -80,8 +80,8 @@ read only at request time inside the proxy.
 
 - The shim-and-replace pairing cannot be partially configured. Either both halves are present
   in the rendered policy or neither.
-- Future credential-injection work (provider API keys in `m16`, GitHub REST APIs in `m17`, and host credential helpers
-  in `m19`) can define new shim kinds without adopting a generic env-export surface that would be hard to constrain.
+- Future credential-injection work (provider API keys in `m17`, GitHub REST APIs in `m18`, and host credential helpers
+  in `m20`) can define new shim kinds without adopting a generic env-export surface that would be hard to constrain.
 - Rendered policy stays small. The `credential_shim` block only appears when something needs
   it, and the payload's only consumer is `/etc/agent-sandbox/shell-init.sh`.
 

--- a/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
@@ -22,8 +22,8 @@ request-aware rules, semantic GitHub service expansion, hot reload, integration 
 
 **Excluded:**
 - Secret injection, header substitution, or other credential features from `m15`
-- GitHub REST wrapper work from `m17`
-- Monitoring UI or interactive unblock workflows from `m18`
+- GitHub REST wrapper work from `m18`
+- Monitoring UI or interactive unblock workflows from `m19`
 - Non-HTTP protocols
 - Header matching and request body inspection. For now, a matched URL rule implies the endpoint is trusted to receive
   the full request.

--- a/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/execution-log.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/execution-log.md
@@ -166,7 +166,7 @@ expanded fragments participate in the existing host-record merge path.
 ## 2026-04-16 15:12 UTC - Drafted the task plan and locked the intended boundary
 
 Reviewed the `m14` milestone plan, project learnings, decision record `005`, the current `render-policy`
-implementation, the `m14.2` matcher boundary, and the downstream `m17` GitHub wrapper goals. The main planning
+implementation, the `m14.2` matcher boundary, and the downstream `m18` GitHub wrapper goals. The main planning
 conclusion is that `m14.3` should not push GitHub-specific behavior into the matcher. Service semantics belong at
 render time and should compile into the same canonical host-record IR that authored `domains` already use.
 

--- a/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/task.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/tasks/m14.3-semantic-service-catalog/task.md
@@ -182,7 +182,7 @@ For GitHub `git`, the intended `readonly` mapping is:
 That keeps clone and fetch working under `readonly: true` while still excluding push.
 
 That is enough to keep repo-scoped Git transport visible in the URL path and to support `m15` credential injection
-without quietly broadening the host allowlist. `m17` remains about the higher-level REST wrapper surface; adding Git
+without quietly broadening the host allowlist. `m18` remains about the higher-level REST wrapper surface; adding Git
 smart-HTTP to `m14.3` does not replace that milestone.
 
 #### Merge And Override Semantics
@@ -353,5 +353,5 @@ Test runs after the simplify pass:
 - If future services duplicate the pattern of "named surfaces plus scoped selectors," revisit whether the per-service
   Python expander can be factored into a shared helper; `m14.3` deliberately resisted that abstraction until a second
   rich service exists.
-- Downstream `m17` still owns the GitHub REST wrapper work; the repo-scoped `api` surface added here intentionally
+- Downstream `m18` still owns the GitHub REST wrapper work; the repo-scoped `api` surface added here intentionally
   stops at URL-shape filtering. Credential-aware behavior belongs to `m15`.

--- a/docs/plan/milestones/m15-proxy-secret-injection/milestone.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/milestone.md
@@ -35,12 +35,12 @@ to hold the real secret.
 - Request body mutation
 - Request, response, header, or URL scanning for leaked secret values
 - Replacing every credential flow with proxy injection
-- A full host credential helper service; that remains `m19`
+- A full host credential helper service; that remains `m20`
 - macOS Keychain-backed secret resolution; m15 should preserve the extension point but ship file-backed storage first
 - A complete secret-management CLI with project, target, and session scoped storage
 - A new live-update control plane beyond the existing policy reload path
-- Provider API-key injection; that moves to `m16`
-- GitHub REST wrapper work; that moves to `m17`
+- Provider API-key injection; that moves to `m17`
+- GitHub REST wrapper work; that moves to `m18`
 
 ## Design
 

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/execution-log.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/execution-log.md
@@ -71,8 +71,8 @@ with surface-scoped GitHub mappings. The preferred policy shape is now `git.acce
 `readonly` for unauthenticated GitHub repo-scoped policies, but that compatibility path was removed after confirming the
 syntax had not shipped.
 
-**Decision:** `api.auth` is reserved and rejected in m15.5. Provider API-key behavior belongs to `m16`, and GitHub REST
-wrapper behavior belongs to `m17`.
+**Decision:** `api.auth` is reserved and rejected in m15.5. Provider API-key behavior belongs to `m17`, and GitHub REST
+wrapper behavior belongs to `m18`.
 
 ## 2026-05-07 04:00 UTC - Initial task plan
 

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/task.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/task.md
@@ -146,8 +146,8 @@ services:
         secret: github.agent-sandbox.push-token
 ```
 
-Reject `api.auth` for now with a clear reserved/unsupported error. Provider API-key injection belongs to `m16`, GitHub
-REST wrapper behavior belongs to `m17`, and M15.5 should not imply API credential injection.
+Reject `api.auth` for now with a clear reserved/unsupported error. Provider API-key injection belongs to `m17`, GitHub
+REST wrapper behavior belongs to `m18`, and M15.5 should not imply API credential injection.
 
 For authenticated Git rules, emit the same canonical rule-scoped transform shape as explicit `domains[].transform`
 authoring:

--- a/docs/plan/milestones/m16-hermes/milestone.md
+++ b/docs/plan/milestones/m16-hermes/milestone.md
@@ -1,0 +1,252 @@
+# Milestone: m16 - Hermes Agent Support
+
+## Goal
+
+Add [Hermes](https://hermes-agent.nousresearch.com/docs/) (Nous Research's self-improving agent) as a supported agent
+in Agent Sandbox. Users can initialize, run, and switch to Hermes via the standard `agentbox` workflow.
+
+## Scope
+
+**Included:**
+- Hermes agent Docker image extending the base image, installed from upstream's shell installer at a pinned version
+- CLI templates (compose layer, devcontainer) modeled on the existing provider-agnostic agents (Pi, OpenCode)
+- CLI agent registry update in `internal/runtime/agents.go` and Go test updates
+- Proxy service entry for Hermes infrastructure domains and `hermes` in `KNOWN_AGENTS`
+- `images/build.sh` support, build job in `build-images.yml`, daily version-check workflow
+- Agent documentation (`docs/agents/hermes.md`) and README support-matrix update
+
+**Excluded:**
+- Hermes's non-CLI adapters (Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, DingTalk,
+  Feishu, WeCom, Weixin, QQ Bot, Yuanbao, BlueBubbles, Home Assistant, Microsoft Teams, Google Chat). Hermes ships 20+
+  platform integrations; the sandbox only covers the CLI.
+- Provider-specific proxy domains. Hermes is provider-agnostic (Nous Portal, OpenRouter, OpenAI, or any endpoint); users
+  add the relevant provider service (`claude`, `codex`, `openai`, `gemini`, `openrouter`) to their policy themselves.
+- Hermes's self-improving "skills" persistence semantics beyond mounting the appropriate state volume so learned skills
+  survive container restarts.
+- Proxy-side credential injection for any provider Hermes calls. That work belongs to m17 (provider API-key injection)
+  and is not gated on this milestone.
+
+## Applicable Learnings
+
+- The add-agent skill provides a comprehensive checklist for new agent integrations; follow it closely.
+- Policy layering via Dockerfile COPY overwrites the parent layer's policy cleanly.
+- Provider-agnostic agents must document clearly that the agent service only covers agent infrastructure; users must add
+  a separate provider service to their policy. Pi and OpenCode set the pattern.
+- Daily version-check workflows pick unique cron slots to avoid CI contention (Pi is 11:00 UTC, OpenCode is 12:00 UTC);
+  pick the next unused hour.
+- For agents installed via shell installers that pull from `main`, derive a stable version anchor (release tag or commit
+  SHA) at build time and bake it into the image label, or the version-check workflow has nothing meaningful to compare
+  against.
+
+## Tasks
+
+### m16.1-discovery
+
+**Summary:** Resolve the open questions about Hermes that the public docs do not answer, so subsequent tasks can be
+implemented against known specifics rather than guesses.
+
+**Scope:**
+- Inspect `https://github.com/NousResearch/hermes-agent`, the install script, and any embedded help text to determine:
+  - The actual binary or runtime layout the shell installer produces
+  - Whether the upstream publishes versioned releases or only tracks `main`; identify the strategy for pinning a
+    specific version at image build time
+  - Authentication mechanism and the env var names Hermes reads (e.g., `NOUS_API_KEY`, `OPENROUTER_API_KEY`,
+    `OPENAI_API_KEY`, custom)
+  - Hermes infrastructure domains the CLI contacts directly (model registry, learning loop, telemetry, update checks)
+    distinct from the provider endpoints
+  - Hermes's state directory layout (where learned skills, persona, and session memory are written), so the right volume
+    mount can be defined
+  - Whether Hermes has an internal sandboxing or shell-exec confirmation flag that must be disabled in-container
+    (analogous to OpenAI Codex's `--sandbox-mode none` or OpenCode's permissions config)
+  - Whether Hermes does auto-update or LSP downloads at startup that need disabling (OpenCode required
+    `OPENCODE_DISABLE_AUTOUPDATE` and `OPENCODE_DISABLE_LSP_DOWNLOAD`)
+- Capture findings in a short discovery note under this milestone folder, with citations to source files in the upstream
+  repo. The note feeds m16.2-m16.4 and m16.7.
+
+**Acceptance Criteria:**
+- A discovery note exists under `docs/plan/milestones/m16-hermes/` listing each open question and its resolution (or
+  "not applicable, here is why").
+- The note names the specific env vars, domains, state paths, and feature flags that downstream tasks will use.
+
+**Dependencies:** None.
+
+**Risks:** Upstream may not publish versioned releases. If only `main` is available, this milestone must decide between
+pinning a commit SHA (reproducible but manual updates), tracking `main` with the version-check workflow watching commit
+SHAs, or asking upstream to tag releases. The decision goes in the discovery note.
+
+### m16.2-dockerfile
+
+**Summary:** Build the agent-sandbox-hermes Docker image.
+
+**Scope:**
+- `images/agents/hermes/Dockerfile` extending the base image
+- Install Hermes via its upstream installer at the pinned version chosen in m16.1, not `main`
+- `HERMES_VERSION` build arg with a default matching the pinned version, image labels (`org.opencontainers.image.version`,
+  agent-specific metadata)
+- Create whatever state directory m16.1 identifies, owned by the `dev` user
+- Apply any sandbox-friendly defaults discovered in m16.1 (auto-update disable, permission overrides, etc.)
+- Standard `EXTRA_PACKAGES` build arg and `USER root` → `USER dev` transitions following existing Dockerfiles
+
+**Acceptance Criteria:**
+- `./images/build.sh hermes` produces an image locally.
+- `docker run --rm agent-sandbox-hermes:local hermes --version` (or whatever Hermes's version command is, per m16.1)
+  prints the pinned version.
+- The image carries an OCI version label that matches the pinned version.
+
+**Dependencies:** m16.1 (need the install mechanism, version pinning strategy, and any required runtime flags).
+
+**Risks:** A shell-installer-only upstream is harder to reproduce than `npm install <pkg>@<version>`. If the installer
+fetches `main` unconditionally, the Dockerfile may have to clone the repo at a specific ref and run the installer
+locally rather than from the curl-piped URL.
+
+### m16.3-proxy-domains
+
+**Summary:** Register Hermes in the proxy as a known agent and add its infrastructure service domains.
+
+**Scope:**
+- Add `"hermes"` entry to `SERVICE_DOMAINS` in `images/proxy/addons/enforcer.py` with the domains identified in m16.1
+- Add `"hermes"` to `KNOWN_AGENTS` in `images/proxy/render-policy`
+- If discovery shows Hermes has no infrastructure domains of its own (purely a thin client over user-chosen providers),
+  the hermes service may be defined with an empty domain list, matching the Pi pattern
+- Add a brief comment in the proxy code or in `docs/agents/hermes.md` explaining that provider domains are user-managed
+
+**Acceptance Criteria:**
+- Proxy starts with `AGENTBOX_ACTIVE_AGENT=hermes` without error.
+- Existing proxy Python unit tests still pass.
+- Policy rendering for `hermes` produces the expected merged host records.
+
+**Dependencies:** m16.1 (needs the list of Hermes infrastructure domains).
+
+**Risks:** Hermes's "self-improving" learning loop may push or pull from a Nous Research endpoint at runtime. If that
+endpoint is mandatory, blocking it would break the agent's core differentiator. m16.1 must enumerate this and the
+default service list must reflect what Hermes actually requires.
+
+### m16.4-templates
+
+**Summary:** Add the CLI compose layer and devcontainer templates for Hermes.
+
+**Scope:**
+- `internal/embeddata/templates/hermes/cli/agent.yml` — image ref, named volume(s) for whatever state paths m16.1
+  identifies, environment-variable surface for the auth env vars Hermes uses
+- `internal/embeddata/templates/hermes/devcontainer/devcontainer.json` — layered compose refs, no VS Code extensions
+  (CLI-only agent), JetBrains proxy settings to match the existing pattern
+
+**Acceptance Criteria:**
+- `agentbox init --agent hermes --mode cli` generates a valid compose stack.
+- `agentbox init --agent hermes --mode devcontainer` generates a valid devcontainer config.
+- `docker compose config` on the generated stack resolves without errors.
+
+**Dependencies:** m16.1 (state path layout, env-var surface).
+
+**Risks:** Hermes's persistent "skills" learning means the state volume must cover the right path. Mounting the wrong
+path silently drops learned state across restarts; this should be verified end-to-end in m16.7, not just by config-shape
+asserts.
+
+### m16.5-cli-integration
+
+**Summary:** Register Hermes in the Go CLI agent registry and update tests.
+
+**Scope:**
+- Append `"hermes"` to `supportedAgents` in `internal/runtime/agents.go`
+- Update any Go tests under `internal/` that assert on the agent list, init flows, switch flows, or compose generation
+  with the new entry (mirror what was done for Pi and OpenCode)
+
+**Acceptance Criteria:**
+- `agentbox init --agent hermes` works end-to-end (driven by integration tests where they exist).
+- `agentbox switch --agent hermes` works.
+- `go test ./...` passes.
+
+**Dependencies:** m16.4 (templates must exist for init/switch to find them).
+
+**Risks:** None substantive — this is a mechanical addition modeled on prior agent rollouts.
+
+### m16.6-build-and-ci
+
+**Summary:** Wire Hermes into `images/build.sh` and CI workflows.
+
+**Scope:**
+- Add `HERMES_VERSION` and `HERMES_EXTRA_PACKAGES` defaults, a `build_hermes()` function, and case entries in
+  `images/build.sh`
+- Add `HERMES_IMAGE_NAME` env var and a `build-hermes` job in `.github/workflows/build-images.yml`
+- Create `.github/workflows/check-hermes-version.yml`, daily cron at the next unused hour after the existing agents
+  (Factory 10:00, Pi 11:00, OpenCode 12:00; pick 13:00 UTC unless m16.1 surfaces a reason not to)
+- Add Hermes to the summary job in `build-images.yml`
+- The version-check workflow must use whatever upstream version source m16.1 settles on (GitHub releases, tags, or commit
+  SHAs); `npm view` will not apply
+
+**Acceptance Criteria:**
+- `./images/build.sh hermes` and `./images/build.sh all` both build the Hermes image.
+- The build-images workflow lints clean (`actionlint` or equivalent if used) and the new job follows the existing
+  matrix shape.
+- The version-check workflow follows the same trigger-on-update pattern as `check-pi-version.yml`.
+
+**Dependencies:** m16.2 (Dockerfile must exist), m16.1 (version anchor mechanism).
+
+**Risks:** If upstream only publishes `main`, the version-check workflow design will look different from the existing
+agents'. m16.1 should choose the shape so this task does not stall mid-implementation.
+
+### m16.7-docs-and-readme
+
+**Summary:** Document Hermes setup and update the project README.
+
+**Scope:**
+- Create `docs/agents/hermes.md` covering: install path, authentication (the env vars and provider choices identified in
+  m16.1), provider policy setup (which provider services to add depending on Nous Portal vs. OpenRouter vs. OpenAI vs.
+  custom), state persistence across restarts, and any sandbox-specific env vars or flags
+- Update `README.md` supported-agents table with a Hermes row
+- Mark m16 as done in `docs/plan/project.md` and `docs/roadmap.md`
+- End-to-end manual verification: build the image, run `agentbox init --agent hermes`, configure a real provider, run a
+  short Hermes session, verify the state volume persists learned skills across `agentbox down && agentbox up`
+
+**Acceptance Criteria:**
+- `docs/agents/hermes.md` exists and covers auth, provider policy setup, and state persistence.
+- README table includes Hermes with correct status indicators.
+- Links are valid.
+- The manual verification session described above completes successfully.
+
+**Dependencies:** All prior tasks.
+
+**Risks:** None substantive.
+
+## Execution Order
+
+1. **m16.1** (discovery) first — blocks everything else
+2. **m16.2** (Dockerfile), **m16.3** (proxy), **m16.4** (templates) in parallel — independent
+3. **m16.5** (CLI integration) — after m16.4
+4. **m16.6** (build + CI) — after m16.2
+5. **m16.7** (docs + manual verify) — after everything else
+
+Critical path: m16.1 → m16.4 → m16.5 → m16.7.
+
+## Risks
+
+- **Undocumented upstream surface.** Hermes's public docs do not specify auth env vars, API endpoints, state layout, or
+  internal sandbox flags. m16.1 is structured to surface these before any code is written; without it, downstream tasks
+  would be guesses. If m16.1 cannot answer a question from upstream source, the milestone may have to file an upstream
+  issue and pause.
+- **Versioning model unknown.** If upstream does not publish releases or tags, the standard `version-check` workflow
+  shape (single npm/GitHub-releases query) will not transfer. The discovery task must propose a workable shape (commit
+  SHA tracking, release-tag tracking after upstream cooperation, or accepting `main` with an explicit "unstable" label
+  on the image).
+- **Provider posture confusion.** Like Pi and OpenCode, Hermes can talk to several providers. New users will assume the
+  `hermes` service is sufficient. Mitigation: docs must lead with provider policy setup, and the agent.yml template
+  comments should call it out at the touch points.
+- **Self-improving state.** Hermes claims to persist learned skills and a model of the user across sessions. If the
+  state volume mount is wrong, this differentiator silently breaks. Mitigation: m16.7 includes an explicit cross-restart
+  verification step rather than relying on config-shape tests alone.
+
+## Definition of Done
+
+- `agentbox init --agent hermes` works in both CLI and devcontainer modes.
+- Hermes image builds locally and via CI; daily version-check workflow runs and reports correctly.
+- Proxy allows Hermes-specific infrastructure domains (or none, if discovery confirms Hermes has no infrastructure
+  domains of its own) and blocks everything else not in the user's policy.
+- `agentbox switch --agent hermes` works without losing other agents' state.
+- `go test ./...` and the proxy Python test suite both pass with Hermes added.
+- `docs/agents/hermes.md`, README support matrix, project plan, and roadmap all reflect m16 as done.
+- A manual session confirms Hermes successfully calls at least one provider through the proxy, and learned state
+  persists across a container restart.
+
+## Changes
+
+(None yet)

--- a/docs/plan/milestones/m17-provider-api-key-injection/milestone.md
+++ b/docs/plan/milestones/m17-provider-api-key-injection/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m16 - Provider API-Key Injection
+# Milestone: m17 - Provider API-Key Injection
 
 ## Goal
 
@@ -26,7 +26,7 @@ Excluded:
 - Copilot and Factory primary auth, unless a concrete API-key flow is identified during discovery
 - OAuth, browser login, device-code, refresh-token, and subscription-login flows
 - Request-body mutation, response mutation, or scanning for leaked secret values
-- Local delivery of real credentials into the agent container; residual cases stay with `m19-host-credential-service`
+- Local delivery of real credentials into the agent container; residual cases stay with `m20-host-credential-service`
 - Arbitrary user-authored env exports that are not paired with catalog-owned proxy replacement rules
 - Clients that copy env credentials into query strings, request bodies, signatures, or local auth stores in a way the
   proxy cannot safely replace
@@ -52,7 +52,7 @@ Excluded:
 
 ## Tasks
 
-### m16.1-provider-auth-discovery-and-schema
+### m17.1-provider-auth-discovery-and-schema
 
 **Summary:** Confirm provider request shapes and define the authored service schema for API-key injection.
 
@@ -75,7 +75,7 @@ Excluded:
 **Risks:** Agent CLIs may validate API-key formats before making network requests, which could make a simple fake env var
 insufficient for some clients.
 
-### m16.2-raw-header-transform
+### m17.2-raw-header-transform
 
 **Summary:** Add a generic transform that injects the resolved secret as the complete header value.
 
@@ -96,7 +96,7 @@ insufficient for some clients.
 **Risks:** A too-specific transform name could leak provider assumptions into the generic injection layer. Keep this
 strictly header-value-oriented.
 
-### m16.3-provider-service-catalog-auth
+### m17.3-provider-service-catalog-auth
 
 **Summary:** Teach the service catalog to emit provider-specific request rules and header transforms.
 
@@ -113,12 +113,12 @@ strictly header-value-oriented.
 - Unauthenticated service entries preserve current behavior
 - Renderer tests reject unsupported auth keys and malformed secret IDs
 
-**Dependencies:** `m16.1`, `m16.2`
+**Dependencies:** `m17.1`, `m17.2`
 
 **Risks:** Existing simple service names have broad host expansion. Adding auth must not accidentally inject credentials
 into unrelated login, telemetry, documentation, or update hosts.
 
-### m16.4-generic-env-credential-shim
+### m17.4-generic-env-credential-shim
 
 **Summary:** Build a generic renderer-owned env-var shim primitive and wire provider API-key uses through the catalog.
 
@@ -140,13 +140,13 @@ into unrelated login, telemetry, documentation, or update hosts.
   shell-init consumer contract
 - Authored top-level shim metadata remains rejected
 
-**Dependencies:** `m16.3`
+**Dependencies:** `m17.3`
 
 **Risks:** Some clients may inspect key prefixes, copy the fake value into a query string or request body, or use the env
 value to sign requests before making a replaceable HTTP request. Those clients may need a provider-specific shim or may
 remain out of scope.
 
-### m16.5-agent-flow-integration
+### m17.5-agent-flow-integration
 
 **Summary:** Wire and document the supported first-rollout agent flows.
 
@@ -162,12 +162,12 @@ remain out of scope.
 - Each unsupported flow has a clear explanation instead of a silent omission
 - Agent docs no longer recommend putting real supported provider API keys inside the container as the primary path
 
-**Dependencies:** `m16.4`
+**Dependencies:** `m17.4`
 
 **Risks:** Live-provider validation can be hard to run in CI. Prefer mocked proxy integration tests plus documented manual
 smoke checks.
 
-### m16.6-docs-examples-and-tests
+### m17.6-docs-examples-and-tests
 
 **Summary:** Add end-user docs, policy examples, and regression coverage for the full provider API-key injection path.
 
@@ -182,21 +182,21 @@ smoke checks.
 - Tests exercise the examples or share fixtures with them
 - Proxy logs remain useful without leaking secret material
 
-**Dependencies:** `m16.2`, `m16.3`, `m16.4`
+**Dependencies:** `m17.2`, `m17.3`, `m17.4`
 
 **Risks:** Duplicating grammar details across docs can drift. Keep `docs/policy/schema.md` canonical and link to it from
 agent-specific pages.
 
 ## Execution Order
 
-1. Start with `m16.1` to lock the provider surface and avoid implementing a schema around guessed client behavior.
-2. Implement `m16.2` early because Anthropic and Gemini need raw API-key headers.
-3. Add catalog auth in `m16.3`.
-4. Add the generic env shim primitive in `m16.4` only after the catalog owns the provider auth rules it pairs with.
-5. Validate and document agent flows in `m16.5`.
-6. Finish with the docs, examples, and regression sweep in `m16.6`.
+1. Start with `m17.1` to lock the provider surface and avoid implementing a schema around guessed client behavior.
+2. Implement `m17.2` early because Anthropic and Gemini need raw API-key headers.
+3. Add catalog auth in `m17.3`.
+4. Add the generic env shim primitive in `m17.4` only after the catalog owns the provider auth rules it pairs with.
+5. Validate and document agent flows in `m17.5`.
+6. Finish with the docs, examples, and regression sweep in `m17.6`.
 
-`m16.2` can proceed in parallel with part of `m16.1` once the raw-header need is confirmed. `m16.5` should not start until
+`m17.2` can proceed in parallel with part of `m17.1` once the raw-header need is confirmed. `m17.5` should not start until
 the shim behavior exists.
 
 ## Risks

--- a/docs/plan/milestones/m18-github-rest-wrapper/milestone.md
+++ b/docs/plan/milestones/m18-github-rest-wrapper/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m17 - GitHub REST Wrapper
+# Milestone: m18 - GitHub REST Wrapper
 
 Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
 URLs and can be constrained by `m14` policies. The goal is not to replace stock `gh` wholesale; it is to provide a
@@ -76,7 +76,7 @@ This milestone should not invent a second credential path. It should use `m15` p
 the wrapper's REST calls can be matched safely by host, method, and path. Residual flows that require the client to
 receive credential material belong in later helper work:
 
-- `m19` for residual helper-based flows
+- `m20` for residual helper-based flows
 
 ### Distribution
 
@@ -92,7 +92,7 @@ This milestone may later become its own open-source project. The current rationa
 an obvious standalone-binary equivalent to `gh` that intentionally stays on REST-only endpoints for use in constrained
 environments with network proxy inspection.
 
-That project-boundary decision is deferred for now. `m17` should proceed in a way that keeps extraction feasible later:
+That project-boundary decision is deferred for now. `m18` should proceed in a way that keeps extraction feasible later:
 
 - keep the wrapper surface narrow and well documented
 - avoid coupling the command surface too tightly to Agent Sandbox internals

--- a/docs/plan/milestones/m20-host-credential-service/milestone.md
+++ b/docs/plan/milestones/m20-host-credential-service/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m19 - Host Credential Service
+# Milestone: m20 - Host Credential Service
 
 Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m15-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
 

--- a/docs/plan/milestones/m6-cli/milestone.md
+++ b/docs/plan/milestones/m6-cli/milestone.md
@@ -25,7 +25,7 @@ Give developers a single command-line tool that handles the full lifecycle of an
 **Excluded:**
 - Go rewrite (m13)
 - Fine-grained proxy rules (m14)
-- Interactive monitoring/unblocking (now tracked for m18)
+- Interactive monitoring/unblocking (now tracked for m19)
 
 ## Applicable Learnings
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -255,7 +255,32 @@ Make the proxy the primary credential path for HTTP-native auth by keeping real 
 
 **Dependencies:** m14 (request-phase MITM matching), m3 (proxy foundation)
 
-### m16-provider-api-key-injection
+### m16-hermes
+
+Add [Hermes](https://hermes-agent.nousresearch.com/docs/) (Nous Research's self-improving agent) as a supported agent
+in Agent Sandbox. Users can initialize, run, and switch to Hermes via the standard `agentbox` workflow.
+
+**Goals:**
+- agent-sandbox-hermes Docker image extending the base image
+- Install Hermes from its upstream shell installer with a pinned version, not `main`
+- CLI templates (compose layer, devcontainer) following the established pattern for provider-agnostic agents
+- Register Hermes in `internal/runtime/agents.go` and update Go tests
+- Proxy service entry: Hermes-specific domains plus `hermes` in `KNOWN_AGENTS`
+- `images/build.sh` support, build job in `build-images.yml`, daily version-check workflow
+- Agent docs (`docs/agents/hermes.md`) and README support-matrix update
+- Discovery first: Hermes's public docs do not enumerate auth env vars, API endpoints, telemetry, or sandbox-relevant
+  flags, so the milestone opens with a discovery task before any code is written
+
+**Out of scope:**
+- Non-CLI Hermes integrations (Telegram, Discord, Slack, WhatsApp, Signal, etc.) — Hermes ships 20+ adapters; the
+  sandbox only covers CLI mode
+- Hermes's self-improving "skills" persistence behavior beyond ensuring the relevant state volume is mounted
+- Provider-specific proxy domains; users add `claude`, `codex`, `openai`, `gemini`, or `openrouter` services to their
+  policy based on which provider they point Hermes at
+
+**Dependencies:** m13 (Go CLI defines the registration surface), m8 (agent switching), m3 (proxy)
+
+### m17-provider-api-key-injection
 
 Extend the `m15` proxy-side credential model from GitHub Git auth to model-provider API-key traffic, so current agents
 can call supported provider APIs without the real API key being readable inside the agent container.
@@ -280,7 +305,7 @@ can call supported provider APIs without the real API key being readable inside 
 
 **Dependencies:** m15 (proxy-side secret injection), m14 (request-phase matching and transforms)
 
-### m17-github-rest-wrapper
+### m18-github-rest-wrapper
 
 Provide an officially supported GitHub wrapper that uses REST-only endpoints so repo identity stays visible in request
 URLs and can be constrained by `m14` policies.
@@ -300,7 +325,7 @@ URLs and can be constrained by `m14` policies.
 
 **Dependencies:** m14 (fine-grained proxy and repo/path-aware policy matching), m15 (primary HTTP credential path)
 
-### m18-cli-monitoring
+### m19-cli-monitoring
 
 CLI tools for monitoring proxy activity and managing policy interactively.
 
@@ -312,7 +337,7 @@ CLI tools for monitoring proxy activity and managing policy interactively.
 
 **Dependencies:** m13 (Go CLI), m14 (fine-grained proxy and hot reload)
 
-### m19-host-credential-service
+### m20-host-credential-service
 
 Add a narrower, secondary credential path for tools and auth flows that cannot be handled cleanly by proxy-side injection.
 

--- a/docs/plan/research/alternatives.md
+++ b/docs/plan/research/alternatives.md
@@ -1223,7 +1223,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - The WireGuard plus shared-namespace design adds startup ordering and networking complexity without solving the separate IDE control plane that the repo itself documents
   - The packaged workflow is devcontainer- and Claude-shaped, not a neutral multi-agent control plane
 - Open questions:
-  - Could proxy-side secret substitution cover enough of `m19-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
+  - Could proxy-side secret substitution cover enough of `m20-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
   - Do we need transparent capture enough to justify the added WireGuard complexity, given the current explicit proxy plus firewall design already blocks direct egress?
   - Should any sandcat-inspired work land as devcontainer-only hardening rather than as part of the core backend contract?
 - Verdict: `useful supporting reference`
@@ -1315,7 +1315,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - Remote execution or gateway fleet support: no
 - Key strengths:
   - This is a genuine stronger-isolation reference, not just a container-plus-proxy variant
-  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m21-backend-interface`
+  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m22-backend-interface`
   - Network policy is materially richer than our current baseline: host allow-listing, path and method matching, request or response mutation, runtime allow-list edits, and offline mode
   - The VFS layer is more interesting than it first appears; it creates a host-side place to enforce or observe filesystem operations without bind-mounting the host repo directly into the guest
   - Lifecycle persistence and reconciliation are stronger than most research repos in this space
@@ -1336,7 +1336,7 @@ When reviewing an item, capture whether it implements any of these primitives:
 
 - Worth bringing into the vision:
   - a real microVM-backed stronger-isolation backend candidate
-  - host-side VFS and exec control-plane separation as input to `m21-backend-interface`
+  - host-side VFS and exec control-plane separation as input to `m22-backend-interface`
   - richer HTTP policy concepts for `m14`, especially method and path matching plus response shaping
   - lifecycle persistence and explicit garbage-collection or reconcile workflows for leaked sandbox resources
 - Probably not worth bringing in as-is:
@@ -1345,7 +1345,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - assuming a FUSE or VFS workspace model is the right default for local developer ergonomics before measuring it against a shared mount model
 - Research consequence:
   - Treat `matchlock` as a leading reference for the optional stronger-isolation backend and for backend-interface design, not as an argument to replace the current local default before we have comparative measurements
-  - It should directly inform `m21-backend-interface` and `m23-runtime-spikes-vm`
+  - It should directly inform `m22-backend-interface` and `m24-runtime-spikes-vm`
 
 ### strongdm/leash
 
@@ -1445,7 +1445,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - accepting materially different network semantics on macOS and Linux under one policy name without very clear degradation rules
 - Research consequence:
   - Treat `leash` as a leading reference for policy IR, rollout modes, and observability, not as proof that a container boundary alone is sufficient for the project's stronger-isolation backend
-  - It should inform `m20-capability-model` and `m21-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
+  - It should inform `m21-capability-model` and `m22-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
 
 ## Research backlog: commercial products
 
@@ -1656,15 +1656,15 @@ Deliverable:
 
 ## Proposed milestones
 
-### m20-capability-model
+### m21-capability-model
 
 Define the threat model, capability matrix, and backend scorecard.
 
-### m21-backend-interface
+### m22-backend-interface
 
 Define a backend-agnostic runner contract, event schema, and policy compiler boundary.
 
-### m22-runtime-spikes-lite
+### m23-runtime-spikes-lite
 
 Build and compare:
 
@@ -1672,21 +1672,21 @@ Build and compare:
 - OS-native backend
 - gVisor backend
 
-### m23-runtime-spikes-vm
+### m24-runtime-spikes-vm
 
 Build and compare:
 
 - Kata backend
 - One heavy-isolation backend such as Firecracker or full VM
 
-### m24-kubernetes-track
+### m25-kubernetes-track
 
 Only if earlier milestones justify it:
 
 - KubeVirt or Kata on Kubernetes
 - Cilium or similar for L7 policy and observability experiments
 
-### m25-decision-and-integration
+### m26-decision-and-integration
 
 Choose:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,7 +120,15 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Keep GitHub tokens out of the agent container for clone, fetch, and push over smart HTTP
 - Evaluate other HTTP-native clients after the GitHub Git flow is proven
 
-## m16: Provider API-key injection (planned)
+## m16: [Hermes](https://hermes-agent.nousresearch.com/docs/) support (planned)
+
+- agent-sandbox-hermes image and templates for the Nous Research Hermes agent
+- Installation from upstream shell installer with a pinned version
+- Network policy with the Hermes service domains (TBD during discovery)
+- Provider-agnostic posture: Hermes supports Nous Portal, OpenRouter, OpenAI, and custom endpoints; users add the relevant provider service to their policy
+- Scope limited to CLI mode; non-CLI integrations (Telegram, Discord, Slack, etc.) are out of scope
+
+## m17: Provider API-key injection (planned)
 
 - Extend proxy-side secret injection from GitHub Git auth to model-provider API-key traffic
 - Add raw-header injection for provider headers whose value is the secret itself
@@ -130,7 +138,7 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Support Codex, Claude API-key mode, Gemini API-key mode, and provider-backed Pi/OpenCode flows where practical
 - Explicitly exclude OAuth, browser login, device-code, subscription-login, and helper-protocol flows
 
-## m17: GitHub REST wrapper (planned)
+## m18: GitHub REST wrapper (planned)
 
 - Repo-scoped GitHub wrapper using REST-only endpoints
 - Keep repo identity visible in request URLs so m14 policies can constrain access to one repo
@@ -139,14 +147,14 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Define and document the supported subset and explicitly exclude GraphQL-dependent `gh` flows
 - Use `m15` proxy-side credential injection where practical instead of storing GitHub tokens in the agent container
 
-## m18: CLI monitoring and policy management (planned)
+## m19: CLI monitoring and policy management (planned)
 
 - Filtered log view for blocked requests
 - Interactive unblock workflow
 - Integration with hot reload for immediate policy updates
 - UI approach TBD (filtered stream, TUI, or hybrid)
 
-## m19: Host credential service (planned)
+## m20: Host credential service (planned)
 
 - Secondary credential path for flows that cannot be handled by proxy injection
 - Host-side service bridging container to native credential store or helper backend

--- a/docs/upgrades/m14-request-aware-rules.md
+++ b/docs/upgrades/m14-request-aware-rules.md
@@ -114,4 +114,4 @@ A rejected reload emits `"action": "rejected"` with an `error` field and keeps t
 - Request or response mutation.
 - Non-HTTP protocols.
 - Secret injection or credential features (tracked for `m15`).
-- GitHub REST wrapper work (tracked for `m17`).
+- GitHub REST wrapper work (tracked for `m18`).


### PR DESCRIPTION
## Summary

- Insert `m16-hermes` milestone for adding [Hermes](https://hermes-agent.nousresearch.com/docs/) (Nous Research's self-improving agent) as the next supported agent in Agent Sandbox.
- Cascade-renumber all later milestones to make room: active plan `m16-m19` → `m17-m20`, research-tier (in `alternatives.md`) `m20-m25` → `m21-m26`. Sub-task IDs and cross-references shift in lockstep.
- Add full milestone plan with 7 tasks under `docs/plan/milestones/m16-hermes/milestone.md`, opening with a discovery task because Hermes's public docs don't enumerate auth env vars, API endpoints, state directory layout, or sandbox-relevant flags.

## Why the cascade

Inserting Hermes as "next" (m16) shifts every later number by one. References to `m16-m19` live across the active plan, completed milestones' execution logs, decision docs, and the research tier in `alternatives.md`. Renumbering everything in lockstep keeps cross-references honest; leaving historical execution logs alone was considered and rejected here in favor of full consistency.

## Files touched

**Renumber (active plan + research tier):**
- `docs/roadmap.md`, `docs/plan/project.md`
- `docs/plan/decisions/006-credential-shim-is-renderer-owned.md`
- `docs/plan/milestones/m6-cli/milestone.md`
- `docs/plan/milestones/m14-fine-grained-proxy/milestone.md` + `m14.3-semantic-service-catalog/{task,execution-log}.md`
- `docs/plan/milestones/m15-proxy-secret-injection/milestone.md` + `m15.5-service-catalog-auth/{task,execution-log}.md`
- `docs/plan/research/alternatives.md`
- `docs/upgrades/m14-request-aware-rules.md`
- Folder renames via `git mv`: `m16-provider-api-key-injection` → `m17-…`, `m17-github-rest-wrapper` → `m18-…`, `m19-host-credential-service` → `m20-…`

**New milestone:**
- `docs/plan/milestones/m16-hermes/milestone.md` (7 tasks: discovery, Dockerfile, proxy domains, templates, CLI integration, build+CI, docs+verify)

## Notable choices

- **Discovery task first.** Hermes ships a shell installer that pulls from `main`, has 20+ non-CLI adapters, and its public docs don't expose env vars/endpoints/state paths. Task `m16.1` resolves those against the upstream repo before any code is written. If the upstream-source answers aren't available, the milestone is structured to surface that as a blocker rather than ship guesses.
- **Version pinning flagged, not assumed.** The existing `npm view`-shaped version-check workflow may not transfer; discovery decides whether to track release tags, commit SHAs, or accept `main` with an "unstable" label.
- **State-mount verification is in the Definition of Done.** Hermes claims learned skills persist across sessions, so the final task includes a cross-restart manual check, not just config-shape asserts.
