### PR TITLE
Run hermes gateway in background as image default

### DIFF
--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -91,6 +91,10 @@ hermes chat
 
 Subcommands like `hermes model`, `hermes skills`, `hermes doctor`, and `hermes status` work as usual. Run `hermes --help` for the full list.
 
+### Gateway
+
+The image's default command starts `hermes gateway run` in the background when the container comes up, so the gateway is ready without any extra step. The container's lifetime is deliberately decoupled from it: the gateway runs under a `sleep infinity` keep-alive, so if the gateway exits the container stays up and `agentbox exec` keeps working. Gateway output appears in `agentbox logs agent`. To restart it, re-run `hermes gateway run` inside the container (it is not auto-restarted). To launch a different default process instead, set `command:` in `.agent-sandbox/compose/user.agent.hermes.override.yml`.
+
 ## Sandbox environment
 
 The image sets these environment variables to keep Hermes well-behaved inside the locked-down container:

--- a/images/agents/hermes/Dockerfile
+++ b/images/agents/hermes/Dockerfile
@@ -70,6 +70,11 @@ RUN SITE_PACKAGES="$(/opt/hermes/.venv/bin/python -c 'import sysconfig; print(sy
 COPY hermes-wrapper.sh /usr/local/bin/hermes
 RUN chmod 0755 /usr/local/bin/hermes
 
+# Launch script for the image's default command. Starts the gateway in the
+# background and keeps the container alive independently. See the script.
+COPY hermes-gateway-launch.sh /usr/local/bin/hermes-gateway-launch
+RUN chmod 0755 /usr/local/bin/hermes-gateway-launch
+
 # Create hermes state directory (HERMES_HOME default is ~/.hermes)
 RUN mkdir -p /home/dev/.hermes && chown -R dev:dev /home/dev/.hermes
 
@@ -78,6 +83,12 @@ USER dev
 ENV HERMES_HOME="/home/dev/.hermes" \
     HERMES_YOLO_MODE=1 \
     HERMES_DISABLE_LAZY_INSTALLS=1
+
+# Default the image to launching the gateway in the background while keeping
+# the container alive (see hermes-gateway-launch). Overrides the base image's
+# `sleep infinity`. Override via the compose `command:` in a user override
+# file for a different default process.
+CMD ["hermes-gateway-launch"]
 
 LABEL org.opencontainers.image.description="Agent Sandbox with Nous Research Hermes agent"
 LABEL com.mattolson.agentsandbox.hermes-version="${HERMES_VERSION}"

--- a/images/agents/hermes/hermes-gateway-launch.sh
+++ b/images/agents/hermes/hermes-gateway-launch.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Default command for the Hermes image.
+#
+# Starts `hermes gateway run` in the background, then hands the container's
+# main process to `sleep infinity`. This deliberately decouples the
+# container's lifetime from the gateway: if the gateway exits or crashes,
+# the container stays up so `agentbox exec` keeps working and the gateway
+# can be restarted (re-run this script, or `hermes gateway run` by hand).
+#
+# The gateway inherits this process's stdout/stderr, so its logs surface in
+# `agentbox logs agent`. `hermes` resolves to the /usr/local/bin/hermes
+# wrapper on PATH (update/uninstall interception stays intact).
+set -e
+
+hermes gateway run &
+
+exec sleep infinity

--- a/images/agents/hermes/hermes-gateway-launch.sh
+++ b/images/agents/hermes/hermes-gateway-launch.sh
@@ -5,7 +5,7 @@
 # main process to `sleep infinity`. This deliberately decouples the
 # container's lifetime from the gateway: if the gateway exits or crashes,
 # the container stays up so `agentbox exec` keeps working and the gateway
-# can be restarted (re-run this script, or `hermes gateway run` by hand).
+# can be restarted by running `hermes gateway run` by hand.
 #
 # The gateway inherits this process's stdout/stderr, so its logs surface in
 # `agentbox logs agent`. `hermes` resolves to the /usr/local/bin/hermes

--- a/internal/embeddata/templates/hermes/cli/agent.yml
+++ b/internal/embeddata/templates/hermes/cli/agent.yml
@@ -6,6 +6,10 @@ services:
     volumes: []
   agent:
     image: ghcr.io/mattolson/agent-sandbox-hermes:latest
+    # Run tini as PID 1 to reap zombies. The default command backgrounds the
+    # gateway under `sleep infinity`, which never reaps; if the gateway dies
+    # its orphaned children would otherwise accumulate as zombies.
+    init: true
     volumes:
       # Persist Hermes state: learned skills, persona, sessions, credentials
       - hermes-state:/home/dev/.hermes


### PR DESCRIPTION
## Summary

Makes the Hermes sandbox image start `hermes gateway run` automatically when
the container comes up, while keeping the container's lifetime decoupled from
the gateway process.

Previously the image inherited the base `sleep infinity` command, so the
gateway had to be started by hand after `agentbox up`. Now it's ready without
any extra step, but a gateway crash no longer takes the container down.

## Changes

- **`images/agents/hermes/hermes-gateway-launch.sh`** (new) — launch script
  that starts `hermes gateway run` in the background, then `exec sleep infinity`
  as the container's main process. The gateway inherits stdout/stderr so its
  output shows up in `agentbox logs agent`. Started once; not auto-restarted.
- **`images/agents/hermes/Dockerfile`** — `CMD ["hermes-gateway-launch"]`,
  overriding the base image's `sleep infinity`.
- **`internal/embeddata/templates/hermes/cli/agent.yml`** — `init: true` on the
  `agent` service so tini runs as PID 1 and reaps zombies. The default command
  backgrounds the gateway under `sleep infinity`, which never reaps; without
  this, orphaned gateway children would accumulate as zombies.
- **`docs/agents/hermes.md`** — new "Gateway" note describing the automatic
  startup, decoupled lifetime, where to find logs, manual restart, and the
  `command:` override.

## Design notes

- **Why same container instead of a separate gateway service.** Hermes keeps all
  state in `HERMES_HOME`, and interactive `hermes chat` is expected to talk to
  the same local gateway and state. Co-locating them in one container avoids
  concurrent-write conflicts on the shared `hermes-state` volume and duplicate
  firewall/NET_ADMIN setup.
- **Why decouple lifetime.** The container is a long-lived service you
  `agentbox exec` into. Tying its lifetime to the gateway would kill the
  container (and your shell access) on any gateway crash.
- **Why start-once, not auto-restart.** Auto-restart would crash-loop and spam
  logs on a misconfigured gateway, masking the real failure. The gateway starts
  cleanly on a fresh project (verified before `hermes setup`), so a one-shot
  launch is sufficient; restart manually with `hermes gateway run`.

## Migration

Existing Hermes sandboxes need to regenerate the managed compose layer to pick
up `init: true`:

```bash
agentbox switch --agent hermes   # or agentbox init
```

The new image lands via the usual upgrade path:

```bash
agentbox bump
agentbox down && agentbox up
```

## Testing

- Built the image locally (`./images/build.sh hermes`) and ran a fresh project
  pointed at `agent-sandbox-hermes:local`; the gateway starts correctly on
  `agentbox up` without running `hermes setup` first.