### PR TITLE
Match GitHub repo paths case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 - **Consolidated proxy-to-agent runtime volume.** The credential-shim files and the new effective-allowlist export now share a single named volume (`proxy-agentbox-run`) mounted at `/run/agentbox`, replacing the former `proxy-credential-shims` volume mounted at `/run/agentbox/credential-shims`. This avoids nesting two volumes in the same directory tree. Runtime sync migrates existing sandboxes automatically on `agentbox up` (the legacy volume and its mounts are removed and the consolidated volume added); containers must be recreated, not just restarted, and the orphaned `proxy-credential-shims` volume can be pruned.
 
+### Fixed
+
+- **Case-insensitive GitHub repo matching.** Repo-scoped GitHub policy rules now match the owner/repo path segment case-insensitively. GitHub treats `owner/repo` as case-insensitive, but the proxy previously lowercased the generated rule paths and matched them case-sensitively, so a clone or API call using a repository's canonical mixed case (e.g. `RyanLisse/Vitalink`) was blocked while the lowercase form worked. The fix is scoped to the GitHub repo rules; all other path matching stays case-sensitive per RFC 3986.
+
 ## [0.16.0] - 2026-05-30
 
 Hermes agent support from `m16`.

--- a/docs/policy/schema.md
+++ b/docs/policy/schema.md
@@ -150,6 +150,13 @@ Repo-scoped keys:
 
 At least one of `git` or `api` must be present when `repos` is set.
 
+Repo names are normalized to lowercase, and the generated repo path rules are
+matched **case-insensitively** on the owner/repo segment. GitHub treats
+owner/repo as case-insensitive, so a clone or API call using the repository's
+canonical mixed case (for example `RyanLisse/Vitalink`) matches an entry
+authored in any case. This case-insensitivity is scoped to the GitHub repo
+rules; all other path matching remains case-sensitive per RFC 3986.
+
 Surface mapping keys:
 
 - `access`: required. One of `read` or `readwrite`.

--- a/images/proxy/addons/policy_matcher.py
+++ b/images/proxy/addons/policy_matcher.py
@@ -118,6 +118,7 @@ class RuntimeRule:
     methods: tuple[str, ...] | None = None
     path_exact: str | None = None
     path_prefix: str | None = None
+    path_case_insensitive: bool = False
     query_exact: tuple[tuple[str, tuple[str, ...]], ...] | None = None
     transform: RuleTransform | None = None
 
@@ -143,10 +144,16 @@ class RuntimeRule:
         if self.methods is not None and method.upper() not in self.methods:
             return False
 
-        if self.path_exact is not None and path != self.path_exact:
+        # GitHub repo paths are case-insensitive on the owner/repo segment. For
+        # rules flagged accordingly, the stored matchers are already lowercase,
+        # so fold the request path before comparing. All other paths stay
+        # case-sensitive per RFC 3986.
+        candidate_path = path.lower() if self.path_case_insensitive else path
+
+        if self.path_exact is not None and candidate_path != self.path_exact:
             return False
 
-        if self.path_prefix is not None and not path.startswith(self.path_prefix):
+        if self.path_prefix is not None and not candidate_path.startswith(self.path_prefix):
             return False
 
         # query_exact is strict: the full normalized parameter set must match.
@@ -343,10 +350,12 @@ class PolicyMatcher:
                 f"{context} must be a YAML mapping, got {type(rule).__name__}: {rule!r}"
             )
 
-        supported_keys = {"schemes", "methods", "path", "query", "transform"}
+        supported_keys = {"schemes", "methods", "path", "query", "transform", "path_case_insensitive"}
         unknown_keys = sorted(set(rule) - supported_keys)
         if unknown_keys:
             raise PolicyError(f"{context} contains unsupported keys: {unknown_keys}")
+
+        path_case_insensitive = bool(rule.get("path_case_insensitive", False))
 
         schemes_value = rule.get("schemes")
         if not isinstance(schemes_value, list) or not schemes_value:
@@ -406,6 +415,8 @@ class PolicyMatcher:
             normalized_path = PolicyMatcher._normalize_uri_component_for_match(
                 match_value
             )
+            if path_case_insensitive:
+                normalized_path = normalized_path.lower()
             if match_key == "exact":
                 path_exact = normalized_path
             else:
@@ -473,6 +484,7 @@ class PolicyMatcher:
             methods=methods,
             path_exact=path_exact,
             path_prefix=path_prefix,
+            path_case_insensitive=path_case_insensitive,
             query_exact=query_exact,
             transform=transform,
         )

--- a/images/proxy/service_catalog.py
+++ b/images/proxy/service_catalog.py
@@ -136,12 +136,14 @@ _SERVICE_SPECIFIC_KEYS = {
 }
 
 
-def _build_rule(*, schemes=None, methods=None, path=None, query=None):
+def _build_rule(*, schemes=None, methods=None, path=None, query=None, path_case_insensitive=False):
     rule = {"schemes": list(schemes or DEFAULT_RULE_SCHEMES)}
     if methods is not None:
         rule["methods"] = list(methods)
     if path is not None:
         rule["path"] = dict(path)
+        if path_case_insensitive:
+            rule["path_case_insensitive"] = True
     if query is not None:
         rule["query"] = deepcopy(query)
     return rule
@@ -457,11 +459,14 @@ def _expand_simple_service(name, options):
 
 
 def _github_api_rules_for_repo(owner, name, access):
+    # GitHub treats the owner/repo segment case-insensitively, so the generated
+    # paths (built from the lowercased owner/name) are matched case-insensitively
+    # to avoid blocking requests that use the repo's canonical mixed case.
     base = f"/repos/{owner}/{name}"
     methods = list(READONLY_METHODS) if access == ACCESS_READ else None
     return [
-        _build_rule(methods=methods, path={"exact": base}),
-        _build_rule(methods=methods, path={"prefix": base + "/"}),
+        _build_rule(methods=methods, path={"exact": base}, path_case_insensitive=True),
+        _build_rule(methods=methods, path={"prefix": base + "/"}, path_case_insensitive=True),
     ]
 
 
@@ -471,10 +476,12 @@ def _github_smart_http_pair(base, git_service):
             methods=list(READONLY_METHODS),
             path={"exact": base + "/info/refs"},
             query={"exact": {"service": [git_service]}},
+            path_case_insensitive=True,
         ),
         _build_rule(
             methods=list(WRITE_METHODS),
             path={"exact": f"{base}/{git_service}"},
+            path_case_insensitive=True,
         ),
     ]
 

--- a/images/proxy/tests/test_policy_matcher.py
+++ b/images/proxy/tests/test_policy_matcher.py
@@ -292,6 +292,78 @@ class PolicyMatcherTests(unittest.TestCase):
         self.assertEqual(prefix.action, "allowed")
         self.assertEqual(prefix.path, "/v1/files/abc?download=1")
 
+    def test_request_matches_case_insensitive_path_when_flagged(self):
+        # Mirrors github repo rules: the stored matcher is lowercase and flagged
+        # case-insensitive, so a request using the repo's canonical mixed case
+        # still matches.
+        matcher = self.matcher_from_domains(
+            [
+                {
+                    "host": "github.com",
+                    "rules": [
+                        {
+                            "schemes": ["https"],
+                            "methods": ["GET", "HEAD"],
+                            "path": {"exact": "/ryanlisse/vitalink.git/info/refs"},
+                            "path_case_insensitive": True,
+                            "query": {"exact": {"service": ["git-upload-pack"]}},
+                        },
+                        {
+                            "schemes": ["https"],
+                            "path": {"prefix": "/repos/ryanlisse/vitalink/"},
+                            "path_case_insensitive": True,
+                        },
+                    ],
+                }
+            ]
+        )
+
+        mixed_exact = matcher.evaluate_request(
+            "github.com",
+            "https",
+            "GET",
+            "/RyanLisse/Vitalink.git/info/refs?service=git-upload-pack",
+        )
+        mixed_prefix = matcher.evaluate_request(
+            "github.com",
+            "https",
+            "GET",
+            "/repos/RyanLisse/Vitalink/contents/README.md",
+        )
+
+        self.assertEqual(mixed_exact.action, "allowed")
+        self.assertEqual(mixed_prefix.action, "allowed")
+        # The decision preserves the original request path, not the folded one.
+        self.assertEqual(
+            mixed_exact.path,
+            "/RyanLisse/Vitalink.git/info/refs?service=git-upload-pack",
+        )
+
+    def test_request_keeps_paths_case_sensitive_without_flag(self):
+        # Per RFC 3986, paths are case-sensitive unless a rule opts in.
+        matcher = self.matcher_from_domains(
+            [
+                {
+                    "host": "api.example.com",
+                    "rules": [
+                        {
+                            "schemes": ["https"],
+                            "path": {"exact": "/v1/Models"},
+                        }
+                    ],
+                }
+            ]
+        )
+
+        decision = matcher.evaluate_request(
+            "api.example.com",
+            "https",
+            "GET",
+            "/v1/models",
+        )
+
+        self.assertEqual(decision.action, "blocked")
+
     def test_request_matches_exact_query_independent_of_pair_order(self):
         matcher = self.matcher_from_domains(
             [

--- a/images/proxy/tests/test_render_policy.py
+++ b/images/proxy/tests/test_render_policy.py
@@ -679,11 +679,13 @@ services:
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"exact": "/repos/owner/repo"},
+                    "path_case_insensitive": True,
                 },
                 {
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"prefix": "/repos/owner/repo/"},
+                    "path_case_insensitive": True,
                 },
             ],
         )
@@ -695,12 +697,14 @@ services:
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"exact": "/owner/repo.git/info/refs"},
+                    "path_case_insensitive": True,
                     "query": {"exact": {"service": ["git-upload-pack"]}},
                 },
                 {
                     "schemes": ["http", "https"],
                     "methods": ["POST"],
                     "path": {"exact": "/owner/repo.git/git-upload-pack"},
+                    "path_case_insensitive": True,
                 },
             ],
         )
@@ -743,6 +747,7 @@ services:
                 "schemes": ["http", "https"],
                 "methods": ["POST"],
                 "path": {"exact": "/owner/repo.git/git-receive-pack"},
+                "path_case_insensitive": True,
                 "transform": expected_transform,
             },
             git_rules,
@@ -1050,11 +1055,13 @@ services:
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"exact": "/repos/owner/repo"},
+                    "path_case_insensitive": True,
                 },
                 {
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"prefix": "/repos/owner/repo/"},
+                    "path_case_insensitive": True,
                 },
             ],
         )

--- a/images/proxy/tests/test_service_catalog.py
+++ b/images/proxy/tests/test_service_catalog.py
@@ -397,6 +397,14 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
         expansion = self.expand("pi")
         self.assertEqual(expansion["records"], [])
 
+    def test_github_default_catch_all_rules_are_not_case_insensitive(self):
+        # Host-wide catch-all rules have no path, so the case-insensitive flag
+        # must not leak onto them; it only applies to repo-scoped path rules.
+        expansion = self.expand("github")
+        for record in expansion["records"]:
+            for rule in record["rules"]:
+                self.assertNotIn("path_case_insensitive", rule)
+
     def test_github_repo_scoped_readwrite_emits_full_api_and_git_rules(self):
         expansion = self.expand(
             {
@@ -420,10 +428,12 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
                 {
                     "schemes": ["http", "https"],
                     "path": {"exact": "/repos/owner/repo"},
+                    "path_case_insensitive": True,
                 },
                 {
                     "schemes": ["http", "https"],
                     "path": {"prefix": "/repos/owner/repo/"},
+                    "path_case_insensitive": True,
                 },
             ],
         )
@@ -437,6 +447,7 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"exact": "/owner/repo.git/info/refs"},
+                    "path_case_insensitive": True,
                     "query": {"exact": {"service": ["git-upload-pack"]}},
                     "transform": expected_transform,
                 },
@@ -444,12 +455,14 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
                     "schemes": ["http", "https"],
                     "methods": ["POST"],
                     "path": {"exact": "/owner/repo.git/git-upload-pack"},
+                    "path_case_insensitive": True,
                     "transform": expected_transform,
                 },
                 {
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"exact": "/owner/repo.git/info/refs"},
+                    "path_case_insensitive": True,
                     "query": {"exact": {"service": ["git-receive-pack"]}},
                     "transform": expected_transform,
                 },
@@ -457,6 +470,7 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
                     "schemes": ["http", "https"],
                     "methods": ["POST"],
                     "path": {"exact": "/owner/repo.git/git-receive-pack"},
+                    "path_case_insensitive": True,
                     "transform": expected_transform,
                 },
             ],
@@ -516,12 +530,14 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
                     "schemes": ["http", "https"],
                     "methods": ["GET", "HEAD"],
                     "path": {"exact": "/owner/repo.git/info/refs"},
+                    "path_case_insensitive": True,
                     "query": {"exact": {"service": ["git-upload-pack"]}},
                 },
                 {
                     "schemes": ["http", "https"],
                     "methods": ["POST"],
                     "path": {"exact": "/owner/repo.git/git-upload-pack"},
+                    "path_case_insensitive": True,
                 },
             ],
         )
@@ -587,10 +603,12 @@ class ServiceCatalogExpansionTests(unittest.TestCase):
                 {
                     "schemes": ["http", "https"],
                     "path": {"exact": "/repos/owner/a"},
+                    "path_case_insensitive": True,
                 },
                 {
                     "schemes": ["http", "https"],
                     "path": {"prefix": "/repos/owner/a/"},
+                    "path_case_insensitive": True,
                 },
             ],
         )


### PR DESCRIPTION
## Summary

Repo-scoped GitHub policy rules now match the `owner/repo` path segment
case-insensitively. Previously, a clone or API call that used a repository's
canonical mixed case (e.g. `RyanLisse/Vitalink`) was blocked even though the
repo was allowed in policy, while the all-lowercase form worked.

## Bug

GitHub treats `owner/repo` as case-insensitive and serves any case. But the
proxy:

1. **lowercased** the repo when generating rule paths
   (`service_catalog.py` → `/ryanlisse/vitalink.git/...`), and
2. compared request paths **case-sensitively** (`policy_matcher.py`).

So a request to `/RyanLisse/Vitalink.git/info/refs` missed the lowercased rule
and returned `403 Blocked by proxy policy: github.com`. Host matching already
folds case; path matching did not — and GitHub puts the repo in the path.

```
policy:   RyanLisse/Vitalink
blocked:  https://github.com/RyanLisse/Vitalink.git   (canonical mixed case)
worked:   https://github.com/ryanlisse/vitalink.git   (lowercase)
```

Both surfaces were affected: git smart-HTTP (`github.com/<owner>/<repo>.git/...`)
and the REST API (`api.github.com/repos/<owner>/<repo>...`).

## Fix

Scoped case-insensitive path matching for the GitHub repo rules only:

- **`service_catalog.py`** — the repo-scoped git and API rules are flagged with
  `path_case_insensitive: true`. `_build_rule` gained a keyword to set it.
- **`policy_matcher.py`** — `RuntimeRule` carries the flag; flagged rules fold
  the request path to lowercase before comparing (stored matchers are already
  lowercase). `_compile_rule` accepts the new key and lowercases the stored
  exact/prefix matcher when set.

The flag flows catalog → rendered IR → matcher. It is catalog-generated only;
authored `domains` rules cannot set it (render-policy still rejects unknown rule
keys). All non-GitHub path matching stays case-sensitive per RFC 3986, so this
cannot loosen unrelated, legitimately case-sensitive path policies.

## Why not just lowercase all paths

HTTP URIs are not case-insensitive in general. Per RFC 3986 only the scheme and
host are case-insensitive; the path/query are case-sensitive by default, and
whether an origin folds path case is application-specific. GitHub's
case-insensitivity on `owner/repo` is GitHub-specific behavior, so the fix is
deliberately narrow rather than a global path-folding change (which would be a
security regression for any allowlisted host with case-sensitive paths).

## Testing

- `python -m unittest` over `images/proxy/tests` — passes, including:
  - matcher: a flagged rule matches a mixed-case request (exact + prefix); an
    unflagged rule still blocks a case-mismatched path.
  - catalog: host-wide catch-all rules (no path) do not get the flag; existing
    exact-rule assertions updated to include it.
- Manual end-to-end: rendered a `RyanLisse/Vitalink` policy and confirmed
  through the compiled matcher that mixed-case clone, mixed-case
  `git-upload-pack` POST, lowercase clone, and mixed-case API + nested file
  paths are all allowed.

## Docs / changelog

- `docs/policy/schema.md` — GitHub service section notes the case-insensitive
  repo matching and its scoping.
- `CHANGELOG.md` — `[Unreleased]` Fixed entry.

## Notes

- This fixes matching for repos that are already listed in policy; it does not
  change that a repo must be allowlisted. It only removes the case footgun.
