### PR TITLE
Release 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.17.0] - 2026-06-07
+## [0.16.1] - 2026-06-07
 
 Agent self-awareness inside the sandbox.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-07
+
+Agent self-awareness inside the sandbox.
+
 ### Added
 
 - **Agent-visible effective allowlist.** The proxy now writes a sanitized copy of the rendered allowlist to `/run/agentbox/policy.yaml`, mounted read-only into the agent container, so an agent can discover exactly which hosts it can reach without host-side tooling. The export lists only hosts and their scheme/method/path/query matchers; the renderer-owned credential-shim payload and per-rule header `transform` directives (which can reference secret IDs) are stripped, as are any other top-level fields. It is rewritten on proxy restart and on each successful `SIGHUP` reload, and a filesystem error writing it is logged rather than failing proxy startup.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The installer defaults to `~/.local/bin`. To choose a version or install directo
 
 ```bash
 curl -fsSL https://github.com/mattolson/agent-sandbox/releases/latest/download/install.sh | \
-  sh -s -- --version v0.17.0 --install-dir /usr/local/bin
+  sh -s -- --version v0.16.1 --install-dir /usr/local/bin
 ```
 
 For the full manual install process, see the [installation notes](docs/cli.md#manual-install).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The installer defaults to `~/.local/bin`. To choose a version or install directo
 
 ```bash
 curl -fsSL https://github.com/mattolson/agent-sandbox/releases/latest/download/install.sh | \
-  sh -s -- --version v0.16.0 --install-dir /usr/local/bin
+  sh -s -- --version v0.17.0 --install-dir /usr/local/bin
 ```
 
 For the full manual install process, see the [installation notes](docs/cli.md#manual-install).

--- a/scripts/install-agentbox.sh
+++ b/scripts/install-agentbox.sh
@@ -14,7 +14,7 @@ Defaults:
 
 Examples:
   sh install-agentbox.sh
-  sh install-agentbox.sh --version v0.16.0
+  sh install-agentbox.sh --version v0.17.0
   sh install-agentbox.sh --install-dir /usr/local/bin
 EOF
 }

--- a/scripts/install-agentbox.sh
+++ b/scripts/install-agentbox.sh
@@ -14,7 +14,7 @@ Defaults:
 
 Examples:
   sh install-agentbox.sh
-  sh install-agentbox.sh --version v0.17.0
+  sh install-agentbox.sh --version v0.16.1
   sh install-agentbox.sh --install-dir /usr/local/bin
 EOF
 }


### PR DESCRIPTION
## Summary

Release-prep only — no behavior changes. Cuts the accumulated `[Unreleased]`
changes as **0.16.1**, dated 2026-06-07.

Versioning note: the `0.x` line tracks milestones (`0.x` = milestone x). This
release isn't an official milestone, so it ships as a `0.16.1` patch rather than
`0.17.0`.

## Changes

- `CHANGELOG.md` — move the `[Unreleased]` entries under a new `## [0.16.1]`
  heading.
- `README.md` and `scripts/install-agentbox.sh` — bump the example install
  version string to `v0.16.1`.

The CLI version itself is injected at build time (ldflags/git tag), so there is
no source version constant to bump.

## What's in 0.16.1

- **Added** — agent-visible effective allowlist exported to
  `/run/agentbox/policy.yaml`; the built-in `operating-in-agent-sandbox` skill
  baked into the base image.
- **Changed** — consolidated the proxy-to-agent runtime files into a single
  `proxy-agentbox-run` volume mounted at `/run/agentbox` (auto-migrated on
  `agentbox up`).
- **Fixed** — case-insensitive GitHub repo path matching.

## Cutting the release (after merge)

1. Merge to `main`.
2. Tag the resulting `main` commit and push: `git tag v0.16.1 && git push origin
   v0.16.1` — this triggers `release-go-binaries.yml`, which builds the CLI
   archives and a **draft** GitHub release.
3. Publish the draft release.

Note: this PR touches no `images/**`, so it does not rebuild images (those were
already published when the underlying changes merged); image publication is
handled when the release is published.