### PR TITLE
Fix WAL-reset SQLite corruption risk in the hermes image

### DIFF
--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -118,6 +118,16 @@ The upstream `hermes` CLI is the real, unmodified entry point — symlinked onto
 
 The image also plants `sitecustomize.py` in the venv's `site-packages` that does `import readline`. This works around upstream [hermes-agent#15768](https://github.com/NousResearch/hermes-agent/issues/15768): `hermes setup`'s free-text prompts (API keys, paths, y/n) call bare `input()` without importing `readline`, so arrow keys leak escape sequences as literal text instead of doing line editing. Python's `site` module auto-imports any module named `sitecustomize` at interpreter startup, which installs the readline hook before `input()` ever runs. Scoped to the hermes venv only — curses-based menus (`prompt_choice`, `prompt_checklist`) are unaffected.
 
+### SQLite (WAL-reset fix)
+
+Debian bookworm ships SQLite **3.40.1**, which python3.11's `sqlite3` module links dynamically. 3.40.1 is inside the range affected by the SQLite [WAL-reset bug](https://www.sqlite.org/wal.html) (all releases 3.7.0–3.51.2): under WAL mode, two connections in separate threads/processes that write or checkpoint at the same instant can corrupt the database. Because the Hermes **gateway runs as a long-lived background process** while the CLI is a second process on the same state DB, that concurrency pattern is reachable here. Upstream fixed it in **3.51.3** (backports **3.50.7** / **3.44.6**).
+
+The image compiles the official SQLite amalgamation (pinned version, verified against sqlite.org's published SHA3-256) and drops it over the multiarch `libsqlite3.so.0` that Python links. SQLite keeps ABI stability across the 3.x series, so no Python rebuild is needed and `sqlite3.sqlite_version` reports the fixed release.
+
+> **`hermes doctor` note.** Doctor flags SQLite 3.40.1 and tells you to `run hermes update`. Ignore that remedy: it does not apply here. `hermes update` only updates the Hermes *Python package* — it can never change the linked C `libsqlite3` — and in this sandbox it fails outright against the read-only checkout (see [Upgrading](#upgrading)). After a rebuild that includes this fix, the warning clears on its own.
+
+To bump SQLite, update `SQLITE_YEAR`, `SQLITE_VERSION`, and `SQLITE_SHA3_256` together in `images/agents/hermes/Dockerfile` from [sqlite.org/download.html](https://www.sqlite.org/download.html). `SQLITE_VERSION` is the zero-padded `X_YY_ZZ_WW` form (3.51.3 → `3510300`); keep it at or above a fixed release. The build fails closed if `SQLITE_SHA3_256` is unset or mismatched.
+
 ## State persistence
 
 `HERMES_HOME` is mounted on a named Docker volume (`hermes-state`), so learned skills, the persona Hermes builds of you, session history, and any provider credentials survive `agentbox down && agentbox up`. They do NOT survive `agentbox destroy` — that wipes all volumes by design.

--- a/images/agents/hermes/Dockerfile
+++ b/images/agents/hermes/Dockerfile
@@ -8,10 +8,58 @@
 # docs/plan/milestones/m16-hermes/tasks/m16.8-git-install/task.md.
 
 ARG BASE_IMAGE=agent-sandbox-base:local
+
+# --- SQLite builder stage -------------------------------------------------
+# Compile a WAL-reset-fixed SQLite for the runtime image.
+#
+# Debian bookworm ships libsqlite3 3.40.1, which python3.11's `sqlite3` module
+# links dynamically. 3.40.1 is inside the range affected by the SQLite WAL-reset
+# bug (all releases 3.7.0-3.51.2): under WAL mode, two connections in separate
+# threads/processes that write or checkpoint at the same instant can corrupt the
+# database. The hermes gateway runs as a long-lived background process while the
+# CLI is a second process on the same state DB, so this concurrency pattern is
+# reachable here. Fixed upstream in 3.51.3 (backports 3.50.7 / 3.44.6).
+# See https://www.sqlite.org/wal.html and docs/agents/hermes.md.
+#
+# The runtime base ships no compiler (build-essential lives only in base's
+# throwaway git-builder stage), so we build the official amalgamation into a
+# shared object here and COPY only the .so into the final image — the same
+# builder-stage pattern base uses for git and yq. SQLite keeps ABI stability
+# across the 3.x series, so dropping the .so over the linked libsqlite3.so.0
+# needs no Python rebuild. Verified against sqlite.org's published SHA3-256
+# (not SHA-256), checked with python3's hashlib so no extra tooling is required.
+#
+# Bump SQLITE_YEAR, SQLITE_VERSION, and SQLITE_SHA3_256 together from
+# https://www.sqlite.org/download.html. SQLITE_VERSION is the zero-padded
+# X_YY_ZZ_WW form (3.51.3 -> 3510300). Must stay >= 3.51.3 (or a fixed backport).
+FROM ${BASE_IMAGE} AS sqlite-builder
+USER root
+ARG SQLITE_YEAR=2026
+ARG SQLITE_VERSION=3510300
+ARG SQLITE_SHA3_256=ced02ff9738970f338c9c8e269897b554bcda73f6cf1029d49459e1324dbeaea
+RUN set -e && \
+    [ -n "$SQLITE_SHA3_256" ] || { echo "ERROR: SQLITE_SHA3_256 build-arg is required. Copy the SHA3-256 for sqlite-amalgamation-${SQLITE_VERSION}.zip from https://www.sqlite.org/download.html (see docs/agents/hermes.md)." >&2; exit 1; } && \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3 && \
+    curl -fsSL -o /tmp/sqlite.zip \
+      "https://www.sqlite.org/${SQLITE_YEAR}/sqlite-amalgamation-${SQLITE_VERSION}.zip" && \
+    python3 -c "import hashlib; d=hashlib.sha3_256(open('/tmp/sqlite.zip','rb').read()).hexdigest(); exp='$SQLITE_SHA3_256'.strip().lower(); assert d==exp, 'SQLite amalgamation SHA3-256 mismatch: expected %s got %s' % (exp, d)" && \
+    cd /tmp && unzip -q sqlite.zip && cd "sqlite-amalgamation-${SQLITE_VERSION}" && \
+    gcc -O2 -fPIC -shared -Wl,-soname,libsqlite3.so.0 \
+      -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+      -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS5 \
+      -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_JSON1 \
+      -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_DBSTAT_VTAB \
+      -DSQLITE_ENABLE_LOAD_EXTENSION -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+      -DSQLITE_SECURE_DELETE -DSQLITE_THREADSAFE=1 \
+      -o libsqlite3.so.0 sqlite3.c -lm -lpthread -ldl && \
+    mkdir -p /out && cp libsqlite3.so.0 /out/libsqlite3.so.0
+
+# --- Runtime image --------------------------------------------------------
 FROM ${BASE_IMAGE}
 
 # Optional extra apt packages (validated below). base already provides git,
-# build-essential, curl, ripgrep, and ca-certificates; only Python is missing.
+# curl, ripgrep, and ca-certificates; only Python is missing. (base ships no
+# compiler; the SQLite fix above compiles in a separate builder stage.)
 ARG EXTRA_PACKAGES=""
 USER root
 RUN set -e && \
@@ -25,7 +73,26 @@ RUN set -e && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 # python3-dev is deliberately omitted: the chosen extras (cli/mcp/acp) plus core
 # resolve as prebuilt wheels. If a future dep needs to compile from source, add
-# python3-dev here (build-essential is already in the base image).
+# python3-dev AND build-essential here — the runtime base ships no compiler (it
+# lives only in base's throwaway git-builder stage).
+
+# Install the WAL-reset-fixed SQLite built in the sqlite-builder stage over the
+# libsqlite3.so.0 that python3's sqlite3 module links. Runs after the python3
+# install above (which pulls libsqlite3-0, so the target symlink exists). The
+# final python3 check confirms the interpreter now links the fixed release; the
+# glob resolves the multiarch dir without needing a compiler here. See the
+# sqlite-builder stage and docs/agents/hermes.md for the why. `hermes doctor`'s
+# "run hermes update" remedy does not apply in this image — that only updates the
+# Python package, never the linked C library, and the checkout is read-only.
+COPY --from=sqlite-builder /out/libsqlite3.so.0 /tmp/libsqlite3.so.0
+RUN set -e && \
+    SYS="$(ls /usr/lib/*/libsqlite3.so.0 2>/dev/null | head -n1)" && \
+    [ -n "$SYS" ] || { echo "ERROR: system libsqlite3.so.0 not found under /usr/lib" >&2; exit 1; } && \
+    TARGET="$(readlink -f "$SYS")" && \
+    install -m 0644 /tmp/libsqlite3.so.0 "$TARGET" && \
+    rm -f /tmp/libsqlite3.so.0 && \
+    ldconfig && \
+    python3 -c "import sqlite3; v=tuple(map(int, sqlite3.sqlite_version.split('.'))); print('linked SQLite', sqlite3.sqlite_version); assert v >= (3,51,3), f'WAL-reset fix missing: {sqlite3.sqlite_version}'"
 
 # Install a pinned, checksum-verified uv (build-time only) for the locked,
 # editable install below. Download the binary straight from the GitHub release


### PR DESCRIPTION
## Summary

Replace Debian bookworm's SQLite 3.40.1 with a WAL-reset-fixed 3.51.3 build in
the hermes image, so the database SQLite the Hermes gateway and CLI share can't
hit the WAL-reset corruption bug.

## Problem

`hermes doctor` flags the linked SQLite:

```
⚠ SQLite 3.40.1 (WAL-reset bug) (run `hermes update`; fixed versions: 3.51.3+ / 3.50.7 / 3.44.6)
```

- 3.40.1 is what `debian:bookworm-slim` ships, and python3.11's `sqlite3` module
  links it dynamically.
- It sits inside the range affected by the SQLite [WAL-reset bug](https://www.sqlite.org/wal.html)
  (all releases 3.7.0–3.51.2): under WAL mode, two connections in separate
  threads/processes that write or checkpoint at the same instant can corrupt the
  database. Fixed upstream in 3.51.3 (backports 3.50.7 / 3.44.6).
- The hermes **gateway runs as a long-lived background process** while the CLI is
  a second process on the same state DB, so this concurrency pattern is reachable.
- Doctor's `run hermes update` remedy does not apply here: `hermes update` only
  updates the Python package (never the linked C library), and it fails against
  the read-only, root-owned checkout anyway. The only lever is the image.

## Change

- Add a throwaway `sqlite-builder` stage that compiles the official SQLite
  amalgamation (3.51.3) into `libsqlite3.so.0`, then `COPY` only the `.so` into
  the runtime image and drop it over the one python links. SQLite holds ABI
  stability across the 3.x series, so no Python rebuild is needed.
- The runtime base ships no compiler (build-essential lives only in base's
  `git-builder` stage), so compiling in a builder stage — the same pattern base
  uses for git and yq — keeps `build-essential` out of the final image.
- Pin version + checksum as Dockerfile `ARG` defaults, mirroring the existing uv
  pinning. `build.sh` and CI need no changes.
- Verify the download against sqlite.org's published SHA3-256 (SQLite publishes
  SHA3, not SHA-256), checked with python3's `hashlib` — no extra tooling. The
  build **fails closed** if the checksum is empty or mismatched.
- Document the fix and bump procedure in `docs/agents/hermes.md`, including why
  doctor's `hermes update` advice does not apply.
- Correct two stale comments that claimed the base image provides
  `build-essential`.

## Files

- `images/agents/hermes/Dockerfile`
- `docs/agents/hermes.md`

## Testing

Built locally (`./images/build.sh hermes`); the in-image assert prints
`linked SQLite 3.51.3`. Runtime checks against `agent-sandbox-hermes:local`
(entrypoint bypassed, since the firewall init needs the compose stack's caps):

- Venv Python links the fix:
  `--entrypoint …/.venv/bin/python … -c "import sqlite3; print(sqlite3.sqlite_version)"` → `3.51.3`
- `hermes doctor` → `✓ SQLite 3.51.3`, WAL-reset warning gone.
- WAL functional smoke test → `journal_mode: wal`, rows read back, `fts5: True`,
  `version: 3.51.3`.

## Bumping SQLite

Update `SQLITE_YEAR`, `SQLITE_VERSION`, and `SQLITE_SHA3_256` together in
`images/agents/hermes/Dockerfile` from <https://www.sqlite.org/download.html>.
`SQLITE_VERSION` is the zero-padded `X_YY_ZZ_WW` form (3.51.3 → `3510300`); keep
it at or above a fixed release.

## Notes

- The pinned SHA3-256 was computed from the downloaded amalgamation over HTTPS,
  intended to match sqlite.org's published hash for 3.51.3.
- Scope is the hermes image only; other agent images are unaffected.