### PR TITLE
Stop exporting full-layer build cache for single-stage images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -83,6 +83,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+          # mode=max, unlike the single-stage images below: it is the only thing
+          # that caches the git-builder and yq-builder stages, and git is
+          # compiled from source once per target platform (the arm64 pass runs
+          # under QEMU). Losing that layer is the difference between a ~20 minute
+          # job and a few minutes. Keep in step with images/base/Dockerfile.
           cache-to: type=gha,mode=max
 
       - name: Output digest
@@ -135,7 +140,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Proxy image digest - ${{ steps.build.outputs.digest }}"
@@ -200,7 +205,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             CLAUDE_CODE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Claude image digest - ${{ steps.build.outputs.digest }}"
@@ -265,7 +270,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             COPILOT_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Copilot image digest - ${{ steps.build.outputs.digest }}"
@@ -333,7 +338,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             CODEX_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Codex image digest - ${{ steps.build.outputs.digest }}"
@@ -398,7 +403,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             GEMINI_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Gemini image digest - ${{ steps.build.outputs.digest }}"
@@ -467,7 +472,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             FACTORY_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Factory image digest - ${{ steps.build.outputs.digest }}"
@@ -536,7 +541,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             PI_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "Pi image digest - ${{ steps.build.outputs.digest }}"
@@ -605,7 +610,7 @@ jobs:
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             OPENCODE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Output digest
         run: echo "OpenCode image digest - ${{ steps.build.outputs.digest }}"
@@ -709,6 +714,9 @@ jobs:
             HERMES_SEMVER=${{ steps.version.outputs.semver }}
             HERMES_EXTRAS=${{ inputs.hermes_extras || env.HERMES_EXTRAS }}
           cache-from: type=gha
+          # mode=max, unlike the single-stage images: hermes has a sqlite-builder
+          # stage that compiles the SQLite amalgamation once per target platform.
+          # Keep in step with images/agents/hermes/Dockerfile.
           cache-to: type=gha,mode=max
 
       - name: Output digest


### PR DESCRIPTION
## Summary

`build-base` recompiles git from source on every run because the repo's Actions cache is over its size limit and the builder-stage layers keep getting evicted. Eight of the ten image jobs export cache they have no use for, which is what fills it. This switches those eight to `mode=min`.

## Symptom

`build-base` duration on the last four runs, from the Actions API:

```
run 33134253871   21 min
run 33123999224   23 min
run 33097997097   22 min
run 32976931571   25 min
```

Flat, no variance. A warm `git-builder` layer would make that job a few minutes. It is compiling git from source every run — once per target platform, with the arm64 pass under QEMU emulation.

The two compiles per run are correct and expected: `platforms: linux/amd64,linux/arm64` with a `git-builder` stage that declares `FROM debian:bookworm-slim` and so inherits the target platform. That part is not a bug and is not changed here. The bug is that it should be a cache hit and isn't.

## Cause

```
Actions cache usage: 10,639,725,052 bytes (10.64 GB) across 398 entries
GitHub per-repo limit: 10 GB
Largest 100 entries: 9.89 GiB, 97 of them buildkit blobs
```

Over the limit, GitHub evicts least-recently-used entries. The base builder stages are among the casualties, so `cache-from: type=gha` misses and git rebuilds.

All ten image jobs exported `cache-to: type=gha,mode=max`, which writes every intermediate stage layer. Only two images have intermediate stages:

| Image | Builder stages | `mode=max` earns anything |
|---|---|---|
| base | 2 — `git-builder`, `yq-builder` | yes |
| hermes | 1 — `sqlite-builder` | yes |
| proxy + 7 agent images | 0 | no |

Those eight were writing several GB per run that `mode=min` would not, purely crowding out the two builds that need the space.

## Change

`mode=min` for the eight single-stage images: proxy, claude, copilot, codex, gemini, factory, pi, opencode.

`mode=max` retained for base and hermes, each now commented with which builder stages it is protecting and which Dockerfile to keep it in step with.

`cache-from: type=gha` is unchanged on all ten jobs. One file touched.

## Merging this is not sufficient on its own

The existing 10.64 GB does not clear itself — entries persist until evicted or untouched for seven days. Merge alone means the next run still finds a full cache, still evicts the base builder stages, and `build-base` is still ~22 minutes; the benefit would arrive sometime next week.

To get it immediately, purge after merging:

```
gh cache delete --all --repo mattolson/agent-sandbox
```

The first run after the purge will be slow across the board (cold cache, git compiles once more). After that, `build-base` should settle.

## How to confirm it worked

Two runs after the purge:

```
gh api repos/mattolson/agent-sandbox/actions/cache/usage
```

Expect well under 10 GB, and `build-base` down from the flat 21–25 min to single digits.

## Not verified

The size reduction is a reasoned expectation, not a measurement — `mode=max` writes every intermediate layer for eight images that have none worth keeping. The check above is the real test. If usage stays near the ceiling, the next lever is a registry cache (`type=registry,ref=ghcr.io/...:buildcache`), which has no 10 GB cap but costs GHCR storage.

Log downloads need authentication, so the cache-miss was inferred from job duration plus the over-limit cache rather than read from buildkit's own output.

## Out of scope

Removing the QEMU-emulated arm64 git compile entirely — either by cross-compiling `git-builder` from `$BUILDPLATFORM`, or by dropping the source build if a new-enough git is packaged for bookworm. Both are larger changes with real risk: git's Makefile builds and runs host helpers during the build, so cross-compiling it is fiddlier than it looks, and I have not checked what version backports carries. Worth revisiting only if a warm cache turns out not to be enough.