### PR TITLE
Give each image build its own GHA cache scope

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,6 +19,26 @@ on:
         required: false
         default: ''
 
+# Serialize runs of this workflow. Two things break when they overlap:
+#
+#   1. Cache. Each job exports to a fixed scope (scope=base, scope=claude, ...),
+#      so concurrent runs of the same job contend for one scope exactly as the
+#      ten jobs did before they were scoped at all.
+#   2. Tags. Both runs push the same :latest and :hermes-<calver> tags to GHCR,
+#      and the winner is whichever finishes last.
+#
+# Serializing is the fix rather than adding a run dimension to the scope: a
+# per-run scope is never read by a later run, which turns the cache off
+# entirely - the failure this workflow just spent two changes recovering from.
+#
+# cancel-in-progress is false so an in-flight release build is queued behind,
+# not killed. GitHub keeps only one pending run per group and cancels further
+# ones; a dispatch dropped that way is re-sent by the next daily version check,
+# which re-detects the missing tag.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   # Single source for the Hermes extras baked into published images. A

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -82,13 +82,21 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          # scope= is mandatory here, not decoration. type=gha defaults to
+          # scope=buildkit, so without it all ten image jobs write one shared
+          # cache index; they run concurrently, last writer wins, and every
+          # other job's manifest is lost. The layers survive as content-
+          # addressed blobs but nothing points at them, so cache-from restores
+          # nothing. Give every job its own scope. Agent images consume base
+          # through BASE_IMAGE by digest from the registry, not through this
+          # cache, so separate scopes cost no reuse.
+          cache-from: type=gha,scope=base
           # mode=max, unlike the single-stage images below: it is the only thing
           # that caches the git-builder and yq-builder stages, and git is
           # compiled from source once per target platform (the arm64 pass runs
           # under QEMU). Losing that layer is the difference between a ~20 minute
           # job and a few minutes. Keep in step with images/base/Dockerfile.
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,scope=base
 
       - name: Output digest
         run: echo "Base image digest - ${{ steps.build.outputs.digest }}"
@@ -139,8 +147,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=proxy
+          cache-to: type=gha,mode=min,scope=proxy
 
       - name: Output digest
         run: echo "Proxy image digest - ${{ steps.build.outputs.digest }}"
@@ -204,8 +212,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             CLAUDE_CODE_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=claude
+          cache-to: type=gha,mode=min,scope=claude
 
       - name: Output digest
         run: echo "Claude image digest - ${{ steps.build.outputs.digest }}"
@@ -269,8 +277,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             COPILOT_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=copilot
+          cache-to: type=gha,mode=min,scope=copilot
 
       - name: Output digest
         run: echo "Copilot image digest - ${{ steps.build.outputs.digest }}"
@@ -337,8 +345,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             CODEX_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=codex
+          cache-to: type=gha,mode=min,scope=codex
 
       - name: Output digest
         run: echo "Codex image digest - ${{ steps.build.outputs.digest }}"
@@ -402,8 +410,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             GEMINI_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=gemini
+          cache-to: type=gha,mode=min,scope=gemini
 
       - name: Output digest
         run: echo "Gemini image digest - ${{ steps.build.outputs.digest }}"
@@ -471,8 +479,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             FACTORY_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=factory
+          cache-to: type=gha,mode=min,scope=factory
 
       - name: Output digest
         run: echo "Factory image digest - ${{ steps.build.outputs.digest }}"
@@ -540,8 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             PI_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=pi
+          cache-to: type=gha,mode=min,scope=pi
 
       - name: Output digest
         run: echo "Pi image digest - ${{ steps.build.outputs.digest }}"
@@ -609,8 +617,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}@${{ needs.build-base.outputs.digest }}
             OPENCODE_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=opencode
+          cache-to: type=gha,mode=min,scope=opencode
 
       - name: Output digest
         run: echo "OpenCode image digest - ${{ steps.build.outputs.digest }}"
@@ -713,11 +721,11 @@ jobs:
             HERMES_REF=${{ steps.version.outputs.ref }}
             HERMES_SEMVER=${{ steps.version.outputs.semver }}
             HERMES_EXTRAS=${{ inputs.hermes_extras || env.HERMES_EXTRAS }}
-          cache-from: type=gha
+          cache-from: type=gha,scope=hermes
           # mode=max, unlike the single-stage images: hermes has a sqlite-builder
           # stage that compiles the SQLite amalgamation once per target platform.
           # Keep in step with images/agents/hermes/Dockerfile.
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,scope=hermes
 
       - name: Output digest
         run: echo "Hermes image digest - ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -31,12 +31,28 @@ on:
 # per-run scope is never read by a later run, which turns the cache off
 # entirely - the failure this workflow just spent two changes recovering from.
 #
-# cancel-in-progress is false so an in-flight release build is queued behind,
-# not killed. GitHub keeps only one pending run per group and cancels further
-# ones; a dispatch dropped that way is re-sent by the next daily version check,
-# which re-detects the missing tag.
+# cancel-in-progress is false so an in-flight build is queued behind, not
+# killed. GitHub allows one pending run per group and cancels the previously
+# pending one, so the newest request always survives. What that costs depends
+# on the trigger:
+#
+#   push        - nothing. A superseding push run checks out a later commit
+#                 that already contains the dropped one's changes.
+#   dispatch    - nothing durable. Version-check dispatches are re-sent by the
+#                 next daily run once it re-detects the missing tag; a manual
+#                 one is visibly cancelled and can be re-run.
+#   release     - lossy, and nothing recovers it. Release runs are the only
+#                 ones that publish the type=semver tags (the other tag types
+#                 are latest/sha), so a dropped release build leaves those
+#                 versions unpublished for good.
+#
+# So releases get their own group, keyed by tag: never queued behind or
+# cancelled by a push or a dispatch, and distinct releases never cancel each
+# other. Everything else shares one serialized group. The cost is that a
+# release can overlap a push and the two contend for a cache scope - rare, and
+# it degrades cache reuse rather than correctness, which is the right way round.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'release' && github.ref_name || 'shared' }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Summary

`build-base` recompiles git from source on every run because all ten image jobs share a single buildkit cache index and overwrite each other's. This gives each job its own `scope=`.

This supersedes the diagnosis in the previous cache PR, which did not fix the symptom.

## Symptom

`build-base` duration, from the Actions API — the last four runs, all after the `mode=min` change landed:

```
run 33139611831   2026-08-28T03:41   19 min
run 33137537126   2026-08-28T03:10   21 min
run 33136238970   2026-08-28T02:32   21 min
run 33134253871   2026-08-28T01:53   21 min
```

Compared against the four runs before it:

| | Before `mode=min` | After |
|---|---|---|
| Cache usage | 10.64 GB / 398 entries | 9.95 GB / 337 entries |
| `build-base` | 21, 23, 22, 25 min | 21, 21, 21, 19 min |

Unchanged. Git is still compiled from source on every run, once per target platform, with the arm64 pass under QEMU.

## Cause

`type=gha` defaults to `scope=buildkit`. None of the ten build jobs set a scope, so all ten write to **one shared cache index**. They run concurrently, the last job to finish overwrites the index, and every other job's manifest is lost. The layers survive in the blob store — content-addressed and deduplicated — but nothing references them, so `cache-from` restores nothing and every stage rebuilds.

The cache listing shows it directly. All 360 entries, grouped:

```
332  buildkit-blob-1-sha256:<hash>       9.88 GB of orphaned layers
 21  index-buildkit-1-f921bd05#N         ONE index scope, in 21 chunks
  7  (codeql, setup-go — unrelated)
```

Ten independently scoped jobs would produce ten distinct `index-*` keys. There is one.

## Change

`scope=<image>` on both `cache-from` and `cache-to` in all ten jobs — base, proxy, claude, copilot, codex, gemini, factory, pi, opencode, hermes. Twenty lines, one file.

Agent images consume base through `BASE_IMAGE` by digest from the registry, not through this cache, so separating the scopes costs no cross-image reuse.

`mode=min` on the eight single-stage images is kept. It was the wrong fix for this symptom, but it is still correct on its own terms: those images have no intermediate stages, so `mode=max` was exporting layers nothing could use.

## Correction to the previous PR

The earlier change attributed the cache miss to size pressure — the repo sitting over the 10 GB cache limit and evicting the base builder stages. The size number was real, but it was not what broke the restore. Index clobbering was the cause the whole time, and it would have happened at any cache size. Reviewers of that PR should treat its "expected to fix `build-base` duration" claim as withdrawn.

## Merging this is not sufficient on its own

The 9.88 GB of blobs does not clear itself and the shared index is still present. Purge after merging so the first scoped run starts from a clean index rather than fighting eviction:

```
gh cache delete --all --repo mattolson/agent-sandbox
```

The first run after the purge recompiles git once more from cold. `build-base` should drop on the run after that.

## How to confirm it worked

Two runs after the purge:

```
gh api repos/mattolson/agent-sandbox/actions/caches?per_page=100 \
  | jq -r '.actions_caches[] | select(.key|startswith("index-")) | .key'
```

Expect ten distinct index scopes rather than one. And `build-base` should fall from the flat 19–21 min to single digits.

## Not verified

Not verified in CI — I cannot run the workflow from here, and log downloads need authentication, so the cache miss was established from the cache index listing and job durations rather than from buildkit's own output.

If `build-base` is still ~20 minutes two runs after a purge, the next thing to check is whether the `git-builder` stage is being invalidated upstream: `FROM debian:bookworm-slim` resolving to a new digest would legitimately bust the cache, and that is independent of scoping.