### PR TITLE
Ignore Claude Code worktrees under .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude/settings.local.json
+.claude/worktrees/
 .worktrees
 .env
 .idea

--- a/docs/git.md
+++ b/docs/git.md
@@ -17,7 +17,8 @@ The base image avoids that by:
 
 Practical guidance:
 
-- Create shared worktrees under the repo root, for example `.worktrees/feature`
+- Create shared worktrees under the repo root, for example `.worktrees/feature`. Claude Code creates its own under
+  `.claude/worktrees/`, which follows the same rule; both directories are gitignored
 - Use Git 2.48 or newer on the host as well when working with repos that use relative worktree metadata
 - On macOS, prefer Homebrew Git over the older Apple-provided Git when using this workflow
 


### PR DESCRIPTION
## Summary

Claude Code creates worktrees at `.claude/worktrees/<name>` and does not add an ignore rule itself, so the directory showed up as untracked and `git add -A` would have added it as an embedded repository.

This adds `.claude/worktrees/` to `.gitignore` alongside the existing `.worktrees` convention used for other agents, and updates the worktree guidance in `docs/git.md` to mention both locations.

## Context

- No open issue. This is a small hygiene fix, not feature work, so no planning document applies.
- Follows on from #118 (added `.worktrees` to `.gitignore`) and #117 (relative worktree paths).

## Validation

- `git check-ignore -v .claude/worktrees/feature/README.md .worktrees/feature` matches both paths against the intended `.gitignore` lines.
- No Go or proxy tests run: the change touches only `.gitignore` and a docs file, so none are relevant.

## Checklist

- [x] The PR is scoped and focused.
- [x] I linked the relevant issue, if one exists.
- [x] I linked the planning document, if one was required.
- [x] I added or updated tests when behavior changed.
- [x] I updated docs when behavior or workflow changed.
- [x] I called out security-sensitive changes and tradeoffs when relevant.
