### PR TITLE
Append the project name to the devcontainer display name (SANDBOX-60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Devcontainer display name includes the project name.** `agentbox init --name myproject` (or the directory-derived default) now renders `.devcontainer/devcontainer.json` with `"name": "Claude Code Sandbox: myproject"` instead of the generic per-agent name, so VS Code and JetBrains window titles distinguish projects. `agentbox switch` applies the same name. A `name` set in `.devcontainer/devcontainer.user.json` still wins. (#178)
+
 ## [0.17.0] - 2026-09-06
 
 GitHub API access from `m17`, and Hermes installed from a git checkout.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,7 +47,8 @@ Options:
 - `--agent` - Agent type: `claude`, `codex`, `copilot`, `gemini`, `factory`, `pi`, `opencode`
 - `--mode` - Setup mode: `cli`, `devcontainer`
 - `--ide` - IDE for devcontainer mode: `vscode`, `jetbrains`, `none`
-- `--name` - Base project name for Docker Compose
+- `--name` - Base project name for Docker Compose; in devcontainer mode it is also appended to the devcontainer
+  display name (for example `Claude Code Sandbox: myproject`) so IDE windows for different projects are distinguishable
 - `--path` - Project directory (default: current directory)
 - `--batch` - Disable prompts. Requires `--agent` and `--mode`, plus `--ide` for `devcontainer`
 

--- a/internal/scaffold/devcontainer.go
+++ b/internal/scaffold/devcontainer.go
@@ -2,19 +2,56 @@ package scaffold
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mattolson/agent-sandbox/internal/runtime"
 )
 
+// devcontainerNamePattern matches the first "name" string value in a
+// devcontainer template. Every agent template opens with a top-level "name",
+// so the first match is the display name shown by VS Code and JetBrains.
+var devcontainerNamePattern = regexp.MustCompile(`("name"\s*:\s*")([^"]*)(")`)
+
+// applyDevcontainerName appends the project name to the template's display
+// name so IDE window titles distinguish projects, e.g. "Claude Code Sandbox:
+// myproject". It edits the template text in place rather than round-tripping
+// through a JSON map so the template's key order and indentation survive.
+func applyDevcontainerName(templateData []byte, projectName string) ([]byte, error) {
+	if projectName == "" {
+		return templateData, nil
+	}
+	loc := devcontainerNamePattern.FindSubmatchIndex(templateData)
+	if loc == nil {
+		return nil, fmt.Errorf("devcontainer template has no \"name\" field to extend")
+	}
+	escaped, err := json.Marshal(projectName)
+	if err != nil {
+		return nil, err
+	}
+	suffix := string(escaped[1 : len(escaped)-1]) // drop the surrounding quotes
+	valueEnd := loc[5]                            // end of the existing name value
+	out := make([]byte, 0, len(templateData)+len(suffix)+2)
+	out = append(out, templateData[:valueEnd]...)
+	out = append(out, ": "...)
+	out = append(out, suffix...)
+	out = append(out, templateData[valueEnd:]...)
+	return out, nil
+}
+
 func scaffoldDevcontainerUserJSONIfMissing(repoRoot string) error {
 	return writeTemplateIfMissing(filepath.Join(repoRoot, ".devcontainer", "devcontainer.user.json"), "devcontainer/devcontainer.user.json")
 }
 
-func renderDevcontainerJSON(repoRoot string, agent string, outputFile string) error {
+func renderDevcontainerJSON(repoRoot string, agent string, projectName string, outputFile string) error {
 	templateData, err := ReadTemplate(filepath.ToSlash(filepath.Join(agent, "devcontainer", "devcontainer.json")))
+	if err != nil {
+		return err
+	}
+	templateData, err = applyDevcontainerName(templateData, projectName)
 	if err != nil {
 		return err
 	}

--- a/internal/scaffold/devcontainer.go
+++ b/internal/scaffold/devcontainer.go
@@ -34,8 +34,7 @@ func applyDevcontainerName(templateData []byte, projectName string) ([]byte, err
 	}
 	suffix := string(escaped[1 : len(escaped)-1]) // drop the surrounding quotes
 	valueEnd := loc[5]                            // end of the existing name value
-	out := make([]byte, 0, len(templateData)+len(suffix)+2)
-	out = append(out, templateData[:valueEnd]...)
+	out := append([]byte{}, templateData[:valueEnd]...)
 	out = append(out, ": "...)
 	out = append(out, suffix...)
 	out = append(out, templateData[valueEnd:]...)

--- a/internal/scaffold/devcontainer.go
+++ b/internal/scaffold/devcontainer.go
@@ -98,7 +98,7 @@ func mergeJSON(base any, overlay any) any {
 			}
 			return overlay
 		}
-		merged := make(map[string]any, len(baseTyped)+len(overlayTyped))
+		merged := make(map[string]any, len(baseTyped))
 		for key, value := range baseTyped {
 			merged[key] = value
 		}

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -88,7 +88,7 @@ func InitializeDevcontainer(ctx context.Context, params InitParams) error {
 	if err := scaffoldDevcontainerUserJSONIfMissing(params.RepoRoot); err != nil {
 		return err
 	}
-	if err := renderDevcontainerJSON(params.RepoRoot, params.Agent, runtime.DevcontainerJSONFile(params.RepoRoot)); err != nil {
+	if err := renderDevcontainerJSON(params.RepoRoot, params.Agent, params.ProjectName, runtime.DevcontainerJSONFile(params.RepoRoot)); err != nil {
 		return err
 	}
 	if err := writeDevcontainerModeComposeFile(params.RepoRoot, params.IDE, params.ProjectName); err != nil {

--- a/internal/scaffold/init_test.go
+++ b/internal/scaffold/init_test.go
@@ -158,7 +158,7 @@ func TestRenderDevcontainerJSONAppendsUserArrays(t *testing.T) {
 	}
 
 	outputFile := filepath.Join(repoRoot, ".devcontainer", "devcontainer.json")
-	if err := renderDevcontainerJSON(repoRoot, "claude", outputFile); err != nil {
+	if err := renderDevcontainerJSON(repoRoot, "claude", "myproject", outputFile); err != nil {
 		t.Fatalf("renderDevcontainerJSON failed: %v", err)
 	}
 
@@ -166,6 +166,80 @@ func TestRenderDevcontainerJSONAppendsUserArrays(t *testing.T) {
 	extensions := data["customizations"].(map[string]any)["vscode"].(map[string]any)["extensions"].([]any)
 	if len(extensions) != 2 || extensions[0].(string) != "anthropic.claude-code" || extensions[1].(string) != "ms-python.python" {
 		t.Fatalf("unexpected extensions: %v", extensions)
+	}
+	if got := data["name"]; got != "Claude Code Sandbox: myproject" {
+		t.Fatalf("expected composed name to survive the user overlay, got %v", got)
+	}
+}
+
+func TestRenderDevcontainerJSONAppendsProjectNameAndKeepsTemplateFormatting(t *testing.T) {
+	repoRoot := t.TempDir()
+	outputFile := filepath.Join(repoRoot, ".devcontainer", "devcontainer.json")
+	if err := renderDevcontainerJSON(repoRoot, "claude", "myproject", outputFile); err != nil {
+		t.Fatalf("renderDevcontainerJSON failed: %v", err)
+	}
+
+	got, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	template, err := ReadTemplate("claude/devcontainer/devcontainer.json")
+	if err != nil {
+		t.Fatalf("ReadTemplate failed: %v", err)
+	}
+	want := strings.Replace(string(template), `"name": "Claude Code Sandbox"`, `"name": "Claude Code Sandbox: myproject"`, 1)
+	if string(got) != want {
+		t.Fatalf("output should equal the template with only the name extended.\ngot:\n%s\nwant:\n%s", got, want)
+	}
+	if readJSONMap(t, outputFile)["name"] != "Claude Code Sandbox: myproject" {
+		t.Fatalf("composed name did not parse back as expected")
+	}
+}
+
+func TestRenderDevcontainerJSONUserNameOverridesComposedName(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".devcontainer"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".devcontainer", "devcontainer.user.json"), []byte(`{"name": "Custom"}`), 0o644); err != nil {
+		t.Fatalf("write user json: %v", err)
+	}
+
+	outputFile := filepath.Join(repoRoot, ".devcontainer", "devcontainer.json")
+	if err := renderDevcontainerJSON(repoRoot, "claude", "myproject", outputFile); err != nil {
+		t.Fatalf("renderDevcontainerJSON failed: %v", err)
+	}
+	if got := readJSONMap(t, outputFile)["name"]; got != "Custom" {
+		t.Fatalf("user-supplied name should win, got %v", got)
+	}
+}
+
+func TestApplyDevcontainerNameEscapesAndCoversEveryAgent(t *testing.T) {
+	for _, agent := range runtime.SupportedAgents() {
+		template, err := ReadTemplate(agent + "/devcontainer/devcontainer.json")
+		if err != nil {
+			t.Fatalf("%s: ReadTemplate failed: %v", agent, err)
+		}
+		out, err := applyDevcontainerName(template, `my "quoted" project`)
+		if err != nil {
+			t.Fatalf("%s: applyDevcontainerName failed: %v", agent, err)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(out, &doc); err != nil {
+			t.Fatalf("%s: output is not valid JSON: %v", agent, err)
+		}
+		name, _ := doc["name"].(string)
+		if !strings.HasSuffix(name, `: my "quoted" project`) {
+			t.Fatalf("%s: top-level name not extended, got %q", agent, name)
+		}
+	}
+
+	unchanged, err := applyDevcontainerName([]byte(`{"name": "X"}`), "")
+	if err != nil || string(unchanged) != `{"name": "X"}` {
+		t.Fatalf("empty project name should leave the template untouched, got %q err=%v", unchanged, err)
+	}
+	if _, err := applyDevcontainerName([]byte(`{"build": {}}`), "p"); err == nil {
+		t.Fatalf("template without a name field should be rejected")
 	}
 }
 

--- a/internal/scaffold/sync.go
+++ b/internal/scaffold/sync.go
@@ -155,7 +155,7 @@ func EnsureDevcontainerRuntimeFiles(ctx context.Context, params SyncParams) (run
 	if err := scaffoldDevcontainerUserJSONIfMissing(params.RepoRoot); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
-	if err := renderDevcontainerJSON(params.RepoRoot, params.Agent, runtime.DevcontainerJSONFile(params.RepoRoot)); err != nil {
+	if err := renderDevcontainerJSON(params.RepoRoot, params.Agent, target.ProjectName, runtime.DevcontainerJSONFile(params.RepoRoot)); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
 	if err := writeDevcontainerModeComposeFile(params.RepoRoot, target.DevcontainerIDE, target.ProjectName); err != nil {


### PR DESCRIPTION
## Summary

`agentbox init --name` only ever set the Docker Compose project name. The generated `.devcontainer/devcontainer.json` kept the per-agent template name, so VS Code window titles for different projects all read `workspace [Dev Container: Claude Code Sandbox @ ...]`.

- Thread the base project name into `renderDevcontainerJSON` and extend the template's top-level `name` to `<agent name>: <project>`, e.g. `Claude Code Sandbox: myproject`. Both `init` and `switch` render it.
- The edit is textual on the template rather than a JSON round-trip, so key order and indentation of the generated file survive. The project name is JSON-escaped.
- A `name` set in `.devcontainer/devcontainer.user.json` still overrides the composed name, as before.
- Tests cover the composed name with and without a user overlay, formatting preservation, escaping, and that every agent template has a top-level `name` to extend.
- `docs/cli.md` describes the new effect of `--name`; changelog entry under Unreleased.

The `workspace` prefix in the window title comes from `${rootName}` (the container workspace folder) and is unchanged; the distinguishing project string now appears after the colon, as requested in the issue.

Fixes #178. Linear: SANDBOX-60.