### PR TITLE
Create the IDE config directory before mounting it in devcontainer mode

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,10 @@ If `~/.local/bin` is not already on your `PATH`, add it in your shell profile be
 Initializes a project sandbox. Prompts for any options not provided via flags, then writes the managed compose and
 policy layers under `.agent-sandbox/` plus `.devcontainer/devcontainer.json` for devcontainer mode.
 
+In devcontainer mode, `init` also creates the selected IDE's configuration directory (`.vscode/` for VS Code, `.idea/`
+for JetBrains) when it is missing. The managed compose layer bind-mounts that directory read-only into the container
+and does not let Docker create it, so a fresh project would otherwise fail to start.
+
 Options:
 - `--agent` - Agent type: `claude`, `codex`, `copilot`, `gemini`, `factory`, `pi`, `opencode`
 - `--mode` - Setup mode: `cli`, `devcontainer`
@@ -67,7 +71,8 @@ Updates the active agent for an initialized project. For layered CLI projects, s
 agent's managed compose layer, agent-specific user policy scaffold, and agent-specific override scaffold the first time
 that agent is selected. For devcontainer projects, switching also refreshes the centralized `.agent-sandbox` runtime
 files and regenerates `.devcontainer/devcontainer.json` for the selected agent while preserving
-`.devcontainer/devcontainer.user.json` and reusing the stored IDE selection.
+`.devcontainer/devcontainer.user.json` and reusing the stored IDE selection. It also recreates the stored IDE's
+configuration directory (`.vscode/` or `.idea/`) if it is missing.
 
 Options:
 - `--agent` - Agent type

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,6 +57,27 @@ mkdir -p "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"
 chmod 700 "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"
 ```
 
+## Devcontainer fails because `.vscode/` or `.idea/` is missing
+
+Devcontainer mode bind-mounts the selected IDE's configuration directory (`.vscode/` for VS Code, `.idea/` for
+JetBrains) read-only into the agent container so the agent cannot use IDE settings as an escape route. The managed
+compose layer sets `bind.create_host_path: false`, so Docker fails instead of creating the directory itself.
+
+The error mentions that the bind source path does not exist:
+
+```text
+invalid mount config for type "bind": bind source path does not exist: /path/to/project/.vscode
+```
+
+`agentbox init` creates the directory for new projects. Projects initialized with an older release may still lack it.
+Create it and reopen the project in the IDE:
+
+```bash
+mkdir -p .vscode   # or .idea for JetBrains
+```
+
+Running `agentbox switch --agent <agent>` also recreates it.
+
 ## Proxy fails to inject a header (missing or unreadable secret file)
 
 A rule with `transform.request.headers` (or a GitHub `git.auth.secret`) requires the proxy to resolve the named secret at request time. If the file is missing or unreadable, the request is blocked before reaching the upstream and the proxy emits a structured rejection event:

--- a/internal/scaffold/compose.go
+++ b/internal/scaffold/compose.go
@@ -347,13 +347,13 @@ func writeDevcontainerModeComposeFile(repoRoot string, ide string, projectName s
 	doc.Name = runtime.ApplyModeSuffix(projectName, runtime.ModeDevcontainer)
 	doc.Services.Proxy.Volumes = ensureManagedBindMount(doc.Services.Proxy.Volumes, "../policy/policy.devcontainer.yaml", "/etc/agent-sandbox/policy/devcontainer.policy.yaml", true)
 	doc.Services.Agent.Volumes = ensureManagedBindMount(doc.Services.Agent.Volumes, "../../.devcontainer", "/workspace/.devcontainer", true)
+	if dir, ok := ideConfigDir(ide); ok {
+		doc.Services.Agent.Volumes = ensureManagedBindMount(doc.Services.Agent.Volumes, "../../"+dir, "/workspace/"+dir, true)
+	}
 	if ide == "jetbrains" {
-		doc.Services.Agent.Volumes = ensureManagedBindMount(doc.Services.Agent.Volumes, "../../.idea", "/workspace/.idea", true)
 		for _, capability := range []string{"DAC_OVERRIDE", "CHOWN", "FOWNER"} {
 			doc.Services.Agent.CapAdd = ensureString(doc.Services.Agent.CapAdd, capability)
 		}
-	} else if ide == "vscode" {
-		doc.Services.Agent.Volumes = ensureManagedBindMount(doc.Services.Agent.Volumes, "../../.vscode", "/workspace/.vscode", true)
 	}
 
 	return writeComposeDocument(runtime.CLIDevcontainerModeComposeFile(repoRoot), header, doc)

--- a/internal/scaffold/devcontainer.go
+++ b/internal/scaffold/devcontainer.go
@@ -41,6 +41,34 @@ func applyDevcontainerName(templateData []byte, projectName string) ([]byte, err
 	return out, nil
 }
 
+// ideConfigDir returns the workspace-relative IDE configuration directory that
+// devcontainer mode bind-mounts read-only into the agent container for the
+// given IDE. The second result is false when the IDE has no such directory.
+func ideConfigDir(ide string) (string, bool) {
+	switch ide {
+	case "vscode":
+		return ".vscode", true
+	case "jetbrains":
+		return ".idea", true
+	default:
+		return "", false
+	}
+}
+
+// ensureIDEConfigDir creates the IDE configuration directory on the host when
+// it is missing. The devcontainer compose layer mounts it read-only with
+// create_host_path disabled, so Docker refuses to start the container on a
+// fresh project unless the directory already exists. Creating it here keeps
+// the directory user-owned and the read-only mount in place.
+func ensureIDEConfigDir(repoRoot string, ide string) error {
+	dir, ok := ideConfigDir(ide)
+	if !ok {
+		return nil
+	}
+
+	return os.MkdirAll(filepath.Join(repoRoot, dir), 0o755)
+}
+
 func scaffoldDevcontainerUserJSONIfMissing(repoRoot string) error {
 	return writeTemplateIfMissing(filepath.Join(repoRoot, ".devcontainer", "devcontainer.user.json"), "devcontainer/devcontainer.user.json")
 }

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -91,6 +91,9 @@ func InitializeDevcontainer(ctx context.Context, params InitParams) error {
 	if err := renderDevcontainerJSON(params.RepoRoot, params.Agent, params.ProjectName, runtime.DevcontainerJSONFile(params.RepoRoot)); err != nil {
 		return err
 	}
+	if err := ensureIDEConfigDir(params.RepoRoot, params.IDE); err != nil {
+		return err
+	}
 	if err := writeDevcontainerModeComposeFile(params.RepoRoot, params.IDE, params.ProjectName); err != nil {
 		return err
 	}

--- a/internal/scaffold/init_test.go
+++ b/internal/scaffold/init_test.go
@@ -453,3 +453,79 @@ func mapLookup(values map[string]string) func(string) string {
 		return values[key]
 	}
 }
+
+func TestInitializeDevcontainerCreatesIDEConfigDir(t *testing.T) {
+	env := map[string]string{
+		"AGENTBOX_PROXY_IMAGE": "agent-sandbox-proxy:local",
+		"AGENTBOX_AGENT_IMAGE": "agent-sandbox-claude:local",
+	}
+	cases := []struct {
+		ide  string
+		want string
+	}{
+		{ide: "vscode", want: ".vscode"},
+		{ide: "jetbrains", want: ".idea"},
+		{ide: "none", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ide, func(t *testing.T) {
+			repoRoot := t.TempDir()
+			if err := InitializeDevcontainer(context.Background(), InitParams{
+				RepoRoot:    repoRoot,
+				Agent:       "claude",
+				ProjectName: "project-sandbox",
+				IDE:         tc.ide,
+				LookupEnv:   mapLookup(env),
+			}); err != nil {
+				t.Fatalf("InitializeDevcontainer failed: %v", err)
+			}
+
+			for _, dir := range []string{".vscode", ".idea"} {
+				path := filepath.Join(repoRoot, dir)
+				if dir == tc.want {
+					assertDirExists(t, path)
+				} else {
+					assertPathMissing(t, path)
+				}
+			}
+		})
+	}
+}
+
+func TestInitializeDevcontainerPreservesExistingIDEConfigDir(t *testing.T) {
+	repoRoot := t.TempDir()
+	settingsFile := filepath.Join(repoRoot, ".vscode", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsFile), 0o755); err != nil {
+		t.Fatalf("mkdir .vscode: %v", err)
+	}
+	if err := os.WriteFile(settingsFile, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	if err := InitializeDevcontainer(context.Background(), InitParams{
+		RepoRoot:    repoRoot,
+		Agent:       "claude",
+		ProjectName: "project-sandbox",
+		IDE:         "vscode",
+		LookupEnv: mapLookup(map[string]string{
+			"AGENTBOX_PROXY_IMAGE": "agent-sandbox-proxy:local",
+			"AGENTBOX_AGENT_IMAGE": "agent-sandbox-claude:local",
+		}),
+	}); err != nil {
+		t.Fatalf("InitializeDevcontainer failed: %v", err)
+	}
+
+	assertFileContent(t, settingsFile, "{}\n")
+}
+
+func assertDirExists(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected directory %s to exist: %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", path)
+	}
+}

--- a/internal/scaffold/sync.go
+++ b/internal/scaffold/sync.go
@@ -158,6 +158,9 @@ func EnsureDevcontainerRuntimeFiles(ctx context.Context, params SyncParams) (run
 	if err := renderDevcontainerJSON(params.RepoRoot, params.Agent, target.ProjectName, runtime.DevcontainerJSONFile(params.RepoRoot)); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
+	if err := ensureIDEConfigDir(params.RepoRoot, target.DevcontainerIDE); err != nil {
+		return runtime.ActiveTarget{}, err
+	}
 	if err := writeDevcontainerModeComposeFile(params.RepoRoot, target.DevcontainerIDE, target.ProjectName); err != nil {
 		return runtime.ActiveTarget{}, err
 	}

--- a/internal/scaffold/sync_test.go
+++ b/internal/scaffold/sync_test.go
@@ -249,3 +249,28 @@ func (runner *syncStubRunner) Output(_ context.Context, _ string, args []string,
 	}
 	return nil, nil
 }
+
+func TestEnsureDevcontainerRuntimeFilesCreatesIDEConfigDir(t *testing.T) {
+	repoRoot := t.TempDir()
+	testutil.WriteFile(t, repoRoot, ".agent-sandbox/active-target.env", "ACTIVE_AGENT=codex\nDEVCONTAINER_IDE=vscode\nPROJECT_NAME=project-sandbox\n")
+	testutil.WriteFile(t, repoRoot, ".agent-sandbox/compose/base.yml", "services:\n  proxy:\n    image: agent-sandbox-proxy:local\n")
+	testutil.WriteFile(t, repoRoot, ".agent-sandbox/compose/agent.codex.yml", "services:\n  agent:\n    image: agent-sandbox-codex:local\n")
+
+	target, err := EnsureDevcontainerRuntimeFiles(context.Background(), SyncParams{
+		RepoRoot: repoRoot,
+		Agent:    "codex",
+		Stderr:   new(bytes.Buffer),
+	})
+	if err != nil {
+		t.Fatalf("EnsureDevcontainerRuntimeFiles failed: %v", err)
+	}
+	if target.DevcontainerIDE != "vscode" {
+		t.Fatalf("unexpected IDE: %q", target.DevcontainerIDE)
+	}
+
+	assertDirExists(t, filepath.Join(repoRoot, ".vscode"))
+	assertPathMissing(t, filepath.Join(repoRoot, ".idea"))
+
+	modeFile := readCompose(t, runtime.CLIDevcontainerModeComposeFile(repoRoot))
+	assertContainsManagedBind(t, modeFile.Services.Agent.Volumes, "../../.vscode", "/workspace/.vscode", true)
+}


### PR DESCRIPTION
## Summary

`agentbox init --mode devcontainer` fails on the first "Reopen in Container" for any project that does not already have a `.vscode/` (or `.idea/` for JetBrains) directory:

```
invalid mount config for type "bind": bind source path does not exist: /path/to/project/.vscode
```

Devcontainer mode bind-mounts the selected IDE's configuration directory read-only into the agent container so the agent cannot use IDE settings as an escape route (#54, #78). The proxy secret mount work (352c8a2) switched managed bind mounts to `create_host_path: false`, which is the right default, but nothing creates the IDE directory on the host, so every fresh devcontainer project has failed to start since then.

## Change

- Add `ideConfigDir` and `ensureIDEConfigDir` in `internal/scaffold/devcontainer.go`. The first maps an IDE to its config directory, the second creates it on the host when missing.
- Call `ensureIDEConfigDir` from `InitializeDevcontainer` and from `EnsureDevcontainerRuntimeFiles`, so `init`, `switch`, and the runtime commands all create it before the mount is written.
- Derive the mount source in `writeDevcontainerModeComposeFile` from the same mapping so the mount and the directory cannot drift.
- Document the behavior in `docs/cli.md` and add a troubleshooting entry for projects initialized with an older release.

The read-only mount and `create_host_path: false` are unchanged. The directory is created user-owned by agentbox rather than root-owned by Docker.

## Tests

- `TestInitializeDevcontainerCreatesIDEConfigDir` covers `vscode`, `jetbrains`, and `none`.
- `TestInitializeDevcontainerPreservesExistingIDEConfigDir` checks an existing `.vscode/settings.json` survives init.
- `TestEnsureDevcontainerRuntimeFilesCreatesIDEConfigDir` covers the runtime sync path with a stored IDE.

Verified the new tests fail when `ensureIDEConfigDir` is turned into a no-op and pass with it restored. `go test ./...`, `go vet ./...`, and `gofmt -l` are clean.

Not changed: the proxy secret directory outside the workspace is still an explicit user setup step per m15.3, and the CLI-mode `AGENTBOX_MOUNT_*_READONLY` user override mounts still use short syntax where Docker creates missing paths.
