### PR TITLE
Create the default secret directory during init and runtime sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ agentbox init
 
 This prompts interactively for the project name, agent, mode, and IDE when needed, then generates the docker compose and network policy files for the sandbox.
 
+It also creates the host secret directory `~/.config/agent-sandbox/secrets` (mode `0700`) when it is missing. The
+proxy mounts that directory read-only even if you have no secrets yet. On 0.17.0 and earlier, create it yourself
+before starting the sandbox:
+
+```bash
+mkdir -p "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"
+chmod 700 "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"
+```
+
 See the [CLI reference](docs/cli.md) for the full list of commands, flags, and environment variables.
 
 To inspect the configuration after init, use `agentbox policy config` to output the effective network policy and
@@ -255,7 +264,8 @@ See [docs/policy/schema.md](./docs/policy/schema.md) for the full policy format 
 
 The recommended way to clone, fetch, or push private GitHub repos from inside the container is to let the proxy inject the credential. The token lives in a host-side secret directory, never in the container's filesystem or Docker volumes.
 
-Create the secret directory on the host before starting the sandbox:
+`agentbox init` creates the default secret directory. If you point `AGENTBOX_SECRET_DIR` elsewhere, create that
+directory yourself. Then add the token file:
 
 ```bash
 mkdir -p "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,8 +173,10 @@ Managed compose stacks mount the host secret directory read-only into the `proxy
 `/run/secrets/agentbox`. The `agent` service does not receive this mount. Override the host source with
 `AGENTBOX_SECRET_DIR`; it defaults to `${HOME}/.config/agent-sandbox/secrets`.
 
-Agentbox-managed bind mounts set `bind.create_host_path: false`, so a missing directory fails startup
-instead of creating an empty host path silently.
+`agentbox init`, `agentbox switch`, and the runtime commands create the default directory with mode `0700` when it
+is missing. A custom `AGENTBOX_SECRET_DIR` is never created automatically. Agentbox-managed bind mounts set
+`bind.create_host_path: false`, so a missing custom directory fails startup instead of creating an empty host path
+silently.
 
 See [docs/secrets.md](secrets.md) for the host directory layout, permission expectations, secret ID
 grammar, manual provisioning, and freshness contract.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -21,9 +21,10 @@ Agentbox mounts a single host directory into the proxy container, read-only:
 One file per secret. The file name is the secret ID referenced from policy.
 The file contents are the raw secret value with at most one trailing newline.
 
-The directory is mounted with `bind.create_host_path: false`, so Docker
-Compose fails fast instead of silently creating it. Create it yourself before
-`agentbox up`:
+`agentbox init` creates the default location with mode `0700`. The directory
+is mounted with `bind.create_host_path: false`, so Docker Compose fails fast
+instead of silently creating it. If you point `AGENTBOX_SECRET_DIR` somewhere
+else, create that directory yourself before `agentbox up`:
 
 ```bash
 mkdir -p "${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,6 +48,12 @@ Agentbox mounts `${AGENTBOX_SECRET_DIR:-${HOME}/.config/agent-sandbox/secrets}` 
 compose files set `bind.create_host_path: false`, so Docker Compose fails instead of silently creating a missing
 directory.
 
+`agentbox init`, `agentbox switch`, and the runtime commands create the default location with mode `0700`, so this
+failure usually means one of:
+
+- `AGENTBOX_SECRET_DIR` points at a directory that does not exist. Agentbox never creates a custom location.
+- The project was set up with 0.17.0 or earlier, which did not create the default directory.
+
 The error usually mentions that the bind source path does not exist or that the bind mount is invalid.
 
 Create the directory on the host, keep it outside the project workspace, and retry:

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain points HOME at a scratch directory so scaffold code that creates
+// host-side directories, such as the default secret directory, never touches
+// the developer's real home directory during tests.
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "agentbox-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", home)
+	code := m.Run()
+	os.RemoveAll(home)
+	os.Exit(code)
+}

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -48,6 +48,9 @@ func InitializeCLI(ctx context.Context, params InitParams) error {
 	}
 
 	env := loadEnvConfig(params, runtime.ModeCLI)
+	if err := ensureDefaultSecretDir(params.LookupEnv); err != nil {
+		return err
+	}
 	if err := writeCLIBaseComposeFile(ctx, params, env); err != nil {
 		return err
 	}

--- a/internal/scaffold/main_test.go
+++ b/internal/scaffold/main_test.go
@@ -1,0 +1,20 @@
+package scaffold
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain points HOME at a scratch directory so scaffold code that creates
+// host-side directories, such as the default secret directory, never touches
+// the developer's real home directory during tests.
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "agentbox-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", home)
+	code := m.Run()
+	os.RemoveAll(home)
+	os.Exit(code)
+}

--- a/internal/scaffold/secretdir.go
+++ b/internal/scaffold/secretdir.go
@@ -35,24 +35,32 @@ func ensureDefaultSecretDir(lookup func(string) string) error {
 		return nil
 	}
 
-	dir := filepath.Join(home, defaultSecretDirRelative)
-	info, err := os.Stat(dir)
-	if err == nil {
-		if !info.IsDir() {
-			return fmt.Errorf("default secret directory %s exists but is not a directory", dir)
-		}
-		return nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
+	return createSecretDir(filepath.Join(home, defaultSecretDirRelative))
+}
+
+// createSecretDir creates dir with mode 0700. An existing directory keeps its
+// mode. Mkdir is the atomic step, so a concurrent first-run command that wins
+// the race surfaces here as EEXIST and is accepted after confirming the path
+// is a directory.
+func createSecretDir(dir string) error {
 	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
 		return err
 	}
-	if err := os.Mkdir(dir, 0o700); err != nil {
+	err := os.Mkdir(dir, 0o700)
+	if err == nil {
+		// Mkdir applies the umask; make the recommended mode explicit.
+		return os.Chmod(dir, 0o700)
+	}
+	if !errors.Is(err, os.ErrExist) {
 		return err
 	}
 
-	// Mkdir applies the umask; make the recommended mode explicit.
-	return os.Chmod(dir, 0o700)
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("default secret directory %s exists but is not a directory", dir)
+	}
+	return nil
 }

--- a/internal/scaffold/secretdir.go
+++ b/internal/scaffold/secretdir.go
@@ -1,0 +1,58 @@
+package scaffold
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// defaultSecretDirRelative is the default host secret directory below $HOME.
+// It mirrors the default in proxySecretMountSource, which the base compose
+// layer mounts read-only into the proxy.
+const defaultSecretDirRelative = ".config/agent-sandbox/secrets"
+
+// ensureDefaultSecretDir creates the default host secret directory when it is
+// missing. The proxy mount sets create_host_path: false, so the proxy fails to
+// start when the directory does not exist, and nothing in the quick start asks
+// the user to create it.
+//
+// Only the default location is created, with mode 0700 as docs/secrets.md
+// recommends. A custom AGENTBOX_SECRET_DIR is user-named, so a missing path
+// there keeps failing loudly instead of turning a typo into an empty
+// directory. HOME comes from the same lookup docker compose uses to expand
+// ${HOME}; without it the default mount cannot resolve either, so there is
+// nothing to create.
+func ensureDefaultSecretDir(lookup func(string) string) error {
+	if lookup == nil {
+		lookup = os.Getenv
+	}
+	if lookup("AGENTBOX_SECRET_DIR") != "" {
+		return nil
+	}
+	home := lookup("HOME")
+	if home == "" {
+		return nil
+	}
+
+	dir := filepath.Join(home, defaultSecretDirRelative)
+	info, err := os.Stat(dir)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("default secret directory %s exists but is not a directory", dir)
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return err
+	}
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return err
+	}
+
+	// Mkdir applies the umask; make the recommended mode explicit.
+	return os.Chmod(dir, 0o700)
+}

--- a/internal/scaffold/secretdir_test.go
+++ b/internal/scaffold/secretdir_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mattolson/agent-sandbox/internal/testutil"
@@ -121,4 +122,31 @@ func assertSecretDir(t *testing.T, path string, mode os.FileMode) {
 	if got := info.Mode().Perm(); got != mode {
 		t.Fatalf("unexpected mode for %s: got %o want %o", path, got, mode)
 	}
+}
+
+func TestCreateSecretDirToleratesConcurrentCreation(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".config", "agent-sandbox", "secrets")
+
+	const workers = 8
+	errs := make(chan error, workers)
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer done.Done()
+			start.Wait()
+			errs <- createSecretDir(dir)
+		}()
+	}
+	start.Done()
+	done.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent createSecretDir failed: %v", err)
+		}
+	}
+	assertSecretDir(t, dir, 0o700)
 }

--- a/internal/scaffold/secretdir_test.go
+++ b/internal/scaffold/secretdir_test.go
@@ -1,0 +1,124 @@
+package scaffold
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mattolson/agent-sandbox/internal/testutil"
+)
+
+func TestInitializeCLICreatesDefaultSecretDir(t *testing.T) {
+	home := t.TempDir()
+	initializeCLIWithHome(t, home, nil)
+
+	assertSecretDir(t, filepath.Join(home, ".config", "agent-sandbox", "secrets"), 0o700)
+}
+
+func TestInitializeCLILeavesCustomSecretDirAlone(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(t.TempDir(), "custom-secrets")
+	initializeCLIWithHome(t, home, map[string]string{"AGENTBOX_SECRET_DIR": custom})
+
+	assertPathMissing(t, filepath.Join(home, ".config", "agent-sandbox", "secrets"))
+	assertPathMissing(t, custom)
+}
+
+func TestInitializeCLIPreservesExistingSecretDirMode(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "agent-sandbox", "secrets")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	initializeCLIWithHome(t, home, nil)
+
+	assertSecretDir(t, dir, 0o755)
+}
+
+func TestInitializeCLIRejectsSecretPathThatIsNotADirectory(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".config", "agent-sandbox", "secrets")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := InitializeCLI(context.Background(), InitParams{
+		RepoRoot:    t.TempDir(),
+		Agent:       "claude",
+		ProjectName: "project-sandbox",
+		LookupEnv:   mapLookup(secretDirEnv(home, nil)),
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("expected not-a-directory error, got %v", err)
+	}
+}
+
+func TestEnsureCLIAgentRuntimeFilesCreatesDefaultSecretDir(t *testing.T) {
+	repoRoot := t.TempDir()
+	home := t.TempDir()
+	testutil.WriteFile(t, repoRoot, ".agent-sandbox/active-target.env", "ACTIVE_AGENT=claude\n")
+	testutil.WriteFile(t, repoRoot, ".agent-sandbox/compose/base.yml", "services:\n  proxy:\n    image: agent-sandbox-proxy:local\n")
+	testutil.WriteFile(t, repoRoot, ".agent-sandbox/compose/agent.claude.yml", "services:\n  agent:\n    image: agent-sandbox-claude:local\n")
+
+	if _, err := EnsureCLIAgentRuntimeFiles(context.Background(), SyncParams{
+		RepoRoot:  repoRoot,
+		Agent:     "claude",
+		LookupEnv: mapLookup(map[string]string{"HOME": home}),
+	}); err != nil {
+		t.Fatalf("EnsureCLIAgentRuntimeFiles failed: %v", err)
+	}
+
+	assertSecretDir(t, filepath.Join(home, ".config", "agent-sandbox", "secrets"), 0o700)
+}
+
+func TestEnsureDefaultSecretDirSkipsWithoutHome(t *testing.T) {
+	if err := ensureDefaultSecretDir(mapLookup(map[string]string{})); err != nil {
+		t.Fatalf("expected no error without HOME, got %v", err)
+	}
+}
+
+func initializeCLIWithHome(t *testing.T, home string, extra map[string]string) {
+	t.Helper()
+	if err := InitializeCLI(context.Background(), InitParams{
+		RepoRoot:    t.TempDir(),
+		Agent:       "claude",
+		ProjectName: "project-sandbox",
+		LookupEnv:   mapLookup(secretDirEnv(home, extra)),
+	}); err != nil {
+		t.Fatalf("InitializeCLI failed: %v", err)
+	}
+}
+
+func secretDirEnv(home string, extra map[string]string) map[string]string {
+	env := map[string]string{
+		"HOME":                 home,
+		"AGENTBOX_PROXY_IMAGE": "agent-sandbox-proxy:local",
+		"AGENTBOX_AGENT_IMAGE": "agent-sandbox-claude:local",
+	}
+	for key, value := range extra {
+		env[key] = value
+	}
+	return env
+}
+
+func assertSecretDir(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected secret directory %s to exist: %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", path)
+	}
+	if got := info.Mode().Perm(); got != mode {
+		t.Fatalf("unexpected mode for %s: got %o want %o", path, got, mode)
+	}
+}

--- a/internal/scaffold/sync.go
+++ b/internal/scaffold/sync.go
@@ -33,6 +33,9 @@ func EnsureCLIAgentRuntimeFiles(ctx context.Context, params SyncParams) (runtime
 	target.ActiveAgent = params.Agent
 
 	env := loadEnvConfig(InitParams{Agent: params.Agent, LookupEnv: params.LookupEnv}, runtime.ModeCLI)
+	if err := ensureDefaultSecretDir(params.LookupEnv); err != nil {
+		return runtime.ActiveTarget{}, err
+	}
 	if err := ensureCLIBasePolicyRuntimeConfigIfExists(params.RepoRoot); err != nil {
 		return runtime.ActiveTarget{}, err
 	}


### PR DESCRIPTION
## Summary

Every fresh install fails at the first `agentbox up` or "Reopen in Container" unless the user already has `~/.config/agent-sandbox/secrets`:

```
invalid mount config for type "bind": bind source path does not exist: /Users/me/.config/agent-sandbox/secrets
```

The base compose layer mounts that directory read-only into the proxy in both modes with `create_host_path: false` (m15.3, 352c8a2). That flag is the right default, but nothing creates the directory, and the README quick start never asks the user to. The only `mkdir` instruction sits under the GitHub push-token section. This has been the state since May 3.

Follows the rule from the discussion on #191: agentbox creates every directory it names, with the right permissions, and never creates a path the user named.

## Change

- Add `ensureDefaultSecretDir` in `internal/scaffold/secretdir.go`. It creates `$HOME/.config/agent-sandbox/secrets` with mode `0700` when missing, leaves an existing directory untouched (including its mode), and errors if the path exists but is not a directory.
- Only the default location is created. When `AGENTBOX_SECRET_DIR` is set, nothing is created, so a typo in a custom path still fails loudly at startup.
- Call it from `InitializeCLI` and `EnsureCLIAgentRuntimeFiles`, which covers `init`, `switch`, the runtime commands, and both CLI and devcontainer mode.
- Resolve `HOME` through the injected env lookup, the same source docker compose expands `${HOME}` from. Without `HOME` there is nothing to create because the mount cannot resolve either.
- Add `TestMain` in `internal/cli` and `internal/scaffold` pointing `HOME` at a scratch directory, so tests that build commands without an env lookup never touch the developer's real home.
- Docs: README quick start now states what init creates and gives the manual commands for 0.17.0 and earlier; `docs/cli.md`, `docs/secrets.md`, and the troubleshooting entry updated to name the remaining failure causes.

## Why creating it is safe

An empty secret directory is fail-closed: the resolver blocks any request that needs a secret it cannot find and emits a structured rejection. Creating it with `0700` is stricter than the manual step, which users routinely run without the `chmod`, and the proxy only warns about a wrongly permissioned directory. The m15.3 objection was to Docker creating the directory root-owned, not to agentbox creating it.

## Tests

- `TestInitializeCLICreatesDefaultSecretDir` asserts the directory exists with mode `0700`.
- `TestInitializeCLILeavesCustomSecretDirAlone` asserts neither the default nor a custom `AGENTBOX_SECRET_DIR` path is created.
- `TestInitializeCLIPreservesExistingSecretDirMode` asserts an existing `0755` directory keeps its mode.
- `TestInitializeCLIRejectsSecretPathThatIsNotADirectory` asserts a clear error when a file sits at the path.
- `TestEnsureCLIAgentRuntimeFilesCreatesDefaultSecretDir` covers the runtime sync path.
- `TestEnsureDefaultSecretDirSkipsWithoutHome` covers the no-HOME case.

`go test ./...`, `go vet ./...`, and `gofmt -l` are clean.

## Follow-up

A second PR stacked on this branch converts the opt-in override mounts (`shell.d`, `dotfiles`, CLI-mode `.vscode/` and `.idea/`, `.git/`, and the Claude config files) to the same rule.
