### PR TITLE
Create agentbox-named opt-in mount directories and never let Docker create paths

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -188,6 +188,12 @@ mode they are written into user-owned override scaffolds instead of managed file
 written into `.agent-sandbox/compose/user.override.yml` and
 `.agent-sandbox/compose/user.agent.<agent>.override.yml` when those files are first scaffolded.
 
+Optional mounts are written in long form with `bind.create_host_path: false`, so Docker never creates a missing host
+path. When a mount is first scaffolded, agentbox creates the directories it names (`~/.config/agent-sandbox/shell.d`,
+`~/.config/agent-sandbox/dotfiles`, `.idea/`, `.vscode/`) if they are missing. Paths you own (`.git/`,
+`~/.claude/CLAUDE.md`, `~/.claude/settings.json`) are never created. If one is missing, the mount is skipped with a
+warning instead of letting Docker replace it with an empty directory.
+
 - `AGENTBOX_SECRET_DIR` - host directory mounted read-only into the proxy as `/run/secrets/agentbox`; defaults to
   `${HOME}/.config/agent-sandbox/secrets`
 - `AGENTBOX_PROXY_IMAGE` - Docker image for proxy service

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,8 +191,8 @@ written into `.agent-sandbox/compose/user.override.yml` and
 Optional mounts are written in long form with `bind.create_host_path: false`, so Docker never creates a missing host
 path. When a mount is first scaffolded, agentbox creates the directories it names (`~/.config/agent-sandbox/shell.d`,
 `~/.config/agent-sandbox/dotfiles`, `.idea/`, `.vscode/`) if they are missing. Paths you own (`.git/`,
-`~/.claude/CLAUDE.md`, `~/.claude/settings.json`) are never created. If one is missing, the mount is skipped with a
-warning instead of letting Docker replace it with an empty directory.
+`~/.claude/CLAUDE.md`, `~/.claude/settings.json`) are never created. If one is missing, or a file path holds a
+directory instead, the mount is skipped with a warning instead of letting Docker mount the wrong thing.
 
 - `AGENTBOX_SECRET_DIR` - host directory mounted read-only into the proxy as `/run/secrets/agentbox`; defaults to
   `${HOME}/.config/agent-sandbox/secrets`

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -6,7 +6,12 @@ You can optionally mount your dotfiles directory and have them auto-linked into 
 
 ```yaml
 volumes:
-  - ${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro
+  - type: bind
+    source: ${HOME}/.config/agent-sandbox/dotfiles
+    target: /home/dev/.dotfiles
+    read_only: true
+    bind:
+      create_host_path: false
 ```
 
 The entrypoint recursively walks `/home/dev/.dotfiles` and creates symlinks for each file at the corresponding `$HOME` path. Intermediate directories are created as needed.
@@ -49,6 +54,6 @@ alias gs='git status'
 EOF
 ```
 
-`agentbox init` includes volume mounts for dotfiles and shell customizations as commented-out entries in the generated compose file. Uncomment them to enable, or set `AGENTBOX_ENABLE_DOTFILES=true` and `AGENTBOX_ENABLE_SHELL_CUSTOMIZATIONS=true` before running init.
+`agentbox init` includes volume mounts for dotfiles and shell customizations as commented-out entries in the generated compose file. Uncomment them to enable, or set `AGENTBOX_ENABLE_DOTFILES=true` and `AGENTBOX_ENABLE_SHELL_CUSTOMIZATIONS=true` before running init. When set, init also creates the directories if they are missing.
 
 shell.d scripts are sourced from the system-level zshrc (`/etc/zsh/zshrc`), which runs before `~/.zshrc`. This means your dotfiles can include a custom `.zshrc` without breaking this integration.

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -65,7 +65,7 @@ func newEditComposeCommand(opts Options, deps commandDeps) *cobra.Command {
 			if _, ok := runtime.PreferredManagedLayout(repoRoot); !ok {
 				return fmt.Errorf("No layered compose layout found at %s. Run 'agentbox init' first.", repoRoot)
 			}
-			if err := scaffold.EnsureSharedComposeOverride(repoRoot, opts.LookupEnv); err != nil {
+			if err := scaffold.EnsureSharedComposeOverride(repoRoot, opts.LookupEnv, cmd.ErrOrStderr()); err != nil {
 				return err
 			}
 

--- a/internal/embeddata/templates/compose/user.agent.override.yml
+++ b/internal/embeddata/templates/compose/user.agent.override.yml
@@ -1,9 +1,14 @@
 # User-owned compose overrides applied only to one CLI agent layer.
 # Safe to edit. agentbox will not overwrite this file.
 # Paths are resolved relative to .agent-sandbox/compose/.
-# Claude examples:
-#   - ${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro
-#   - ${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro
+# Prefer the long form with create_host_path: false so Docker never creates
+# a missing host path. Claude example:
+#   - type: bind
+#     source: ${HOME}/.claude/CLAUDE.md
+#     target: /home/dev/.claude/CLAUDE.md
+#     read_only: true
+#     bind:
+#       create_host_path: false
 services:
   agent:
     volumes: []

--- a/internal/embeddata/templates/compose/user.override.yml
+++ b/internal/embeddata/templates/compose/user.override.yml
@@ -1,11 +1,18 @@
 # User-owned compose overrides applied to all CLI agents.
 # Safe to edit. agentbox will not overwrite this file.
 # Paths are resolved relative to .agent-sandbox/compose/.
-# Add mounts under services.agent.volumes. For example, to add dotfiles:
+# Add mounts under services.agent.volumes. Prefer the long form with
+# create_host_path: false so Docker never creates a missing host path.
+# For example, to add dotfiles:
 # services:
 #   agent:
 #     volumes:
-#       - ${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro
+#       - type: bind
+#         source: ${HOME}/.config/agent-sandbox/dotfiles
+#         target: /home/dev/.dotfiles
+#         read_only: true
+#         bind:
+#           create_host_path: false
 services:
   agent:
     volumes: []

--- a/internal/scaffold/compose.go
+++ b/internal/scaffold/compose.go
@@ -3,6 +3,7 @@ package scaffold
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -320,9 +321,16 @@ func writeCLIAgentComposeFile(ctx context.Context, params InitParams, env EnvCon
 	return writeComposeDocument(runtime.CLIAgentComposeFile(params.RepoRoot, params.Agent), header, doc)
 }
 
-func writeUserOverrideIfMissing(repoRoot string, outputFile string, templateName string, extraVolumes []string) error {
+// writeUserOverrideIfMissing scaffolds a user-owned override file once. Opt-in
+// mounts are written in long form with create_host_path: false so Docker never
+// creates a missing host path. Agentbox-named directories are created first,
+// and user-named paths that do not exist are skipped with a warning.
+func writeUserOverrideIfMissing(repoRoot string, outputFile string, templateName string, mounts []optionalMount, warn io.Writer) error {
 	if _, err := os.Stat(outputFile); err == nil {
 		return nil
+	}
+	if warn == nil {
+		warn = io.Discard
 	}
 
 	doc, header, err := loadComposeTemplate(templateName)
@@ -330,8 +338,15 @@ func writeUserOverrideIfMissing(repoRoot string, outputFile string, templateName
 		return err
 	}
 	ensureAgentService(&doc)
-	for _, volume := range extraVolumes {
-		doc.Services.Agent.Volumes = ensureVolumeString(doc.Services.Agent.Volumes, volume)
+	for _, mount := range mounts {
+		ready, err := prepareOptionalMount(mount, warn)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			continue
+		}
+		doc.Services.Agent.Volumes = ensureManagedBindMount(doc.Services.Agent.Volumes, mount.source, mount.target, true)
 	}
 
 	return writeComposeDocument(outputFile, header, doc)

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -34,6 +34,9 @@ type EnvConfig struct {
 	MountGitReadonly          bool
 	MountIdeaReadonly         bool
 	MountVSCodeReadonly       bool
+	// Home is the host home directory used to resolve ${HOME} mounts, or ""
+	// when unknown.
+	Home string
 }
 
 func InitializeCLI(ctx context.Context, params InitParams) error {
@@ -54,7 +57,7 @@ func InitializeCLI(ctx context.Context, params InitParams) error {
 	if err := writeCLIBaseComposeFile(ctx, params, env); err != nil {
 		return err
 	}
-	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserOverrideFile(params.RepoRoot), "compose/user.override.yml", optionalSharedVolumes(env)); err != nil {
+	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserOverrideFile(params.RepoRoot), "compose/user.override.yml", optionalSharedMounts(params.RepoRoot, env), params.Stderr); err != nil {
 		return err
 	}
 	if err := scaffoldUserPolicyFileIfMissing(runtime.SharedPolicyFile(params.RepoRoot), "user.policy.yaml"); err != nil {
@@ -66,7 +69,7 @@ func InitializeCLI(ctx context.Context, params InitParams) error {
 	if err := writeCLIAgentComposeFile(ctx, params, env); err != nil {
 		return err
 	}
-	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserAgentOverrideFile(params.RepoRoot, params.Agent), "compose/user.agent.override.yml", optionalAgentVolumes(params.Agent, env)); err != nil {
+	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserAgentOverrideFile(params.RepoRoot, params.Agent), "compose/user.agent.override.yml", optionalAgentMounts(params.Agent, env), params.Stderr); err != nil {
 		return err
 	}
 
@@ -123,6 +126,7 @@ func loadEnvConfig(params InitParams, mode string) EnvConfig {
 		MountGitReadonly:          parseBoolEnv(lookup("AGENTBOX_MOUNT_GIT_READONLY")),
 		MountIdeaReadonly:         parseBoolEnv(lookup("AGENTBOX_MOUNT_IDEA_READONLY")),
 		MountVSCodeReadonly:       parseBoolEnv(lookup("AGENTBOX_MOUNT_VSCODE_READONLY")),
+		Home:                      lookup("HOME"),
 	}
 
 	if mode == runtime.ModeDevcontainer {
@@ -143,38 +147,6 @@ func envOrDefault(value string, fallback string) string {
 	}
 
 	return value
-}
-
-func optionalSharedVolumes(config EnvConfig) []string {
-	volumes := make([]string, 0, 5)
-	if config.EnableShellCustomizations {
-		volumes = append(volumes, `${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro`)
-	}
-	if config.EnableDotfiles {
-		volumes = append(volumes, `${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro`)
-	}
-	if config.MountGitReadonly {
-		volumes = append(volumes, `../../.git:/workspace/.git:ro`)
-	}
-	if config.MountIdeaReadonly {
-		volumes = append(volumes, `../../.idea:/workspace/.idea:ro`)
-	}
-	if config.MountVSCodeReadonly {
-		volumes = append(volumes, `../../.vscode:/workspace/.vscode:ro`)
-	}
-
-	return volumes
-}
-
-func optionalAgentVolumes(agent string, config EnvConfig) []string {
-	if agent != "claude" || !config.MountClaudeConfig {
-		return nil
-	}
-
-	return []string{
-		`${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro`,
-		`${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro`,
-	}
 }
 
 func writeTemplateIfMissing(path string, templateName string) error {

--- a/internal/scaffold/init_test.go
+++ b/internal/scaffold/init_test.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -9,12 +10,18 @@ import (
 	"testing"
 
 	"github.com/mattolson/agent-sandbox/internal/runtime"
+	"github.com/mattolson/agent-sandbox/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
 func TestInitializeCLIWritesRepresentativeClaudeScaffold(t *testing.T) {
 	repoRoot := t.TempDir()
+	home := t.TempDir()
+	testutil.WriteFile(t, repoRoot, ".git/HEAD", "ref: refs/heads/main\n")
+	testutil.WriteFile(t, home, ".claude/CLAUDE.md", "# notes\n")
+	testutil.WriteFile(t, home, ".claude/settings.json", "{}\n")
 	env := map[string]string{
+		"HOME":                                 home,
 		"AGENTBOX_PROXY_IMAGE":                 "agent-sandbox-proxy:local",
 		"AGENTBOX_AGENT_IMAGE":                 "agent-sandbox-claude:local",
 		"AGENTBOX_MOUNT_CLAUDE_CONFIG":         "true",
@@ -57,20 +64,20 @@ func TestInitializeCLIWritesRepresentativeClaudeScaffold(t *testing.T) {
 	assertContainsVolumeString(t, agent.Services.Agent.Volumes, "claude-history:/commandhistory")
 
 	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
-	for _, volume := range []string{
-		`${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro`,
-		`${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro`,
-		`../../.git:/workspace/.git:ro`,
-		`../../.idea:/workspace/.idea:ro`,
-		`../../.vscode:/workspace/.vscode:ro`,
-	} {
-		assertContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, volume)
-	}
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/shell.d", "/home/dev/.config/agent-sandbox/shell.d", true)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/dotfiles", "/home/dev/.dotfiles", true)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "../../.git", "/workspace/.git", true)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "../../.idea", "/workspace/.idea", true)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "../../.vscode", "/workspace/.vscode", true)
 	assertNoProxySecretRuntime(t, sharedOverride.Services.Agent)
+	assertDirExists(t, filepath.Join(home, ".config", "agent-sandbox", "shell.d"))
+	assertDirExists(t, filepath.Join(home, ".config", "agent-sandbox", "dotfiles"))
+	assertDirExists(t, filepath.Join(repoRoot, ".idea"))
+	assertDirExists(t, filepath.Join(repoRoot, ".vscode"))
 
 	agentOverride := readCompose(t, runtime.CLIUserAgentOverrideFile(repoRoot, "claude"))
-	assertContainsVolumeString(t, agentOverride.Services.Agent.Volumes, `${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro`)
-	assertContainsVolumeString(t, agentOverride.Services.Agent.Volumes, `${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro`)
+	assertContainsManagedBind(t, agentOverride.Services.Agent.Volumes, "${HOME}/.claude/CLAUDE.md", "/home/dev/.claude/CLAUDE.md", true)
+	assertContainsManagedBind(t, agentOverride.Services.Agent.Volumes, "${HOME}/.claude/settings.json", "/home/dev/.claude/settings.json", true)
 	assertNoProxySecretRuntime(t, agentOverride.Services.Agent)
 
 	assertAgentboxRunAgentReadOnly(t, base, agent, sharedOverride, agentOverride)
@@ -117,9 +124,9 @@ func TestInitializeDevcontainerWritesRepresentativeCodexScaffold(t *testing.T) {
 	assertNoProxySecretRuntime(t, modeFile.Services.Agent)
 
 	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
-	assertNotContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, "../../.idea:/workspace/.idea:ro")
-	assertNotContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, "../../.vscode:/workspace/.vscode:ro")
-	assertContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, `${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro`)
+	assertNoVolumeTarget(t, sharedOverride.Services.Agent.Volumes, "/workspace/.idea")
+	assertNoVolumeTarget(t, sharedOverride.Services.Agent.Volumes, "/workspace/.vscode")
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/shell.d", "/home/dev/.config/agent-sandbox/shell.d", true)
 	assertNoProxySecretRuntime(t, sharedOverride.Services.Agent)
 	assertAgentboxRunAgentReadOnly(t, base, modeFile, sharedOverride)
 
@@ -528,4 +535,62 @@ func assertDirExists(t *testing.T, path string) {
 	if !info.IsDir() {
 		t.Fatalf("expected %s to be a directory", path)
 	}
+}
+
+func TestInitializeCLISkipsMissingUserNamedMounts(t *testing.T) {
+	repoRoot := t.TempDir()
+	home := t.TempDir()
+	stderr := new(bytes.Buffer)
+	if err := InitializeCLI(context.Background(), InitParams{
+		RepoRoot:    repoRoot,
+		Agent:       "claude",
+		ProjectName: "project-sandbox",
+		Stderr:      stderr,
+		LookupEnv: mapLookup(map[string]string{
+			"HOME":                         home,
+			"AGENTBOX_PROXY_IMAGE":         "agent-sandbox-proxy:local",
+			"AGENTBOX_AGENT_IMAGE":         "agent-sandbox-claude:local",
+			"AGENTBOX_MOUNT_GIT_READONLY":  "true",
+			"AGENTBOX_MOUNT_CLAUDE_CONFIG": "true",
+		}),
+	}); err != nil {
+		t.Fatalf("InitializeCLI failed: %v", err)
+	}
+
+	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
+	assertNoVolumeTarget(t, sharedOverride.Services.Agent.Volumes, "/workspace/.git")
+	agentOverride := readCompose(t, runtime.CLIUserAgentOverrideFile(repoRoot, "claude"))
+	assertNoVolumeTarget(t, agentOverride.Services.Agent.Volumes, "/home/dev/.claude/CLAUDE.md")
+	assertNoVolumeTarget(t, agentOverride.Services.Agent.Volumes, "/home/dev/.claude/settings.json")
+
+	assertPathMissing(t, filepath.Join(repoRoot, ".git"))
+	assertPathMissing(t, filepath.Join(home, ".claude"))
+	for _, want := range []string{
+		"Skipping mount of /workspace/.git",
+		"Skipping mount of /home/dev/.claude/CLAUDE.md",
+		"Skipping mount of /home/dev/.claude/settings.json",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected warning %q, got %q", want, stderr.String())
+		}
+	}
+}
+
+func TestInitializeCLIKeepsHomeMountsWhenHomeIsUnknown(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := InitializeCLI(context.Background(), InitParams{
+		RepoRoot:    repoRoot,
+		Agent:       "claude",
+		ProjectName: "project-sandbox",
+		LookupEnv: mapLookup(map[string]string{
+			"AGENTBOX_PROXY_IMAGE":     "agent-sandbox-proxy:local",
+			"AGENTBOX_AGENT_IMAGE":     "agent-sandbox-claude:local",
+			"AGENTBOX_ENABLE_DOTFILES": "true",
+		}),
+	}); err != nil {
+		t.Fatalf("InitializeCLI failed: %v", err)
+	}
+
+	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/dotfiles", "/home/dev/.dotfiles", true)
 }

--- a/internal/scaffold/init_test.go
+++ b/internal/scaffold/init_test.go
@@ -594,3 +594,37 @@ func TestInitializeCLIKeepsHomeMountsWhenHomeIsUnknown(t *testing.T) {
 	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
 	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/dotfiles", "/home/dev/.dotfiles", true)
 }
+
+func TestInitializeCLISkipsClaudeConfigPathsThatAreNotFiles(t *testing.T) {
+	repoRoot := t.TempDir()
+	home := t.TempDir()
+	// A directory where CLAUDE.md should be, as Docker left behind before
+	// agentbox stopped letting it create host paths.
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "CLAUDE.md"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	testutil.WriteFile(t, home, ".claude/settings.json", "{}\n")
+	stderr := new(bytes.Buffer)
+
+	if err := InitializeCLI(context.Background(), InitParams{
+		RepoRoot:    repoRoot,
+		Agent:       "claude",
+		ProjectName: "project-sandbox",
+		Stderr:      stderr,
+		LookupEnv: mapLookup(map[string]string{
+			"HOME":                         home,
+			"AGENTBOX_PROXY_IMAGE":         "agent-sandbox-proxy:local",
+			"AGENTBOX_AGENT_IMAGE":         "agent-sandbox-claude:local",
+			"AGENTBOX_MOUNT_CLAUDE_CONFIG": "true",
+		}),
+	}); err != nil {
+		t.Fatalf("InitializeCLI failed: %v", err)
+	}
+
+	agentOverride := readCompose(t, runtime.CLIUserAgentOverrideFile(repoRoot, "claude"))
+	assertNoVolumeTarget(t, agentOverride.Services.Agent.Volumes, "/home/dev/.claude/CLAUDE.md")
+	assertContainsManagedBind(t, agentOverride.Services.Agent.Volumes, "${HOME}/.claude/settings.json", "/home/dev/.claude/settings.json", true)
+	if !strings.Contains(stderr.String(), "Skipping mount of /home/dev/.claude/CLAUDE.md") || !strings.Contains(stderr.String(), "is not a regular file") {
+		t.Fatalf("expected not-a-regular-file warning, got %q", stderr.String())
+	}
+}

--- a/internal/scaffold/optional_mounts.go
+++ b/internal/scaffold/optional_mounts.go
@@ -1,0 +1,101 @@
+package scaffold
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// optionalMount is an opt-in host mount that an AGENTBOX_* environment
+// variable seeds into a user-owned override scaffold.
+type optionalMount struct {
+	// flag is the environment variable that enabled the mount.
+	flag string
+	// source is the compose-side source: ${HOME}/... or a path relative to
+	// .agent-sandbox/compose/.
+	source string
+	// target is the container path.
+	target string
+	// hostPath is the resolved host path, or "" when HOME is unknown.
+	hostPath string
+	// create is true for directories agentbox names and may create when
+	// missing. User-named paths are never created; a missing one skips the
+	// mount instead of letting Docker replace it with an empty directory.
+	create bool
+}
+
+func homeMount(flag string, home string, relative string, target string, create bool) optionalMount {
+	mount := optionalMount{flag: flag, source: "${HOME}/" + relative, target: target, create: create}
+	if home != "" {
+		mount.hostPath = filepath.Join(home, filepath.FromSlash(relative))
+	}
+	return mount
+}
+
+func workspaceMount(flag string, repoRoot string, name string, create bool) optionalMount {
+	return optionalMount{
+		flag:     flag,
+		source:   "../../" + name,
+		target:   "/workspace/" + name,
+		hostPath: filepath.Join(repoRoot, name),
+		create:   create,
+	}
+}
+
+// optionalSharedMounts lists the opt-in mounts for the shared override file.
+func optionalSharedMounts(repoRoot string, config EnvConfig) []optionalMount {
+	mounts := make([]optionalMount, 0, 5)
+	if config.EnableShellCustomizations {
+		mounts = append(mounts, homeMount("AGENTBOX_ENABLE_SHELL_CUSTOMIZATIONS", config.Home, ".config/agent-sandbox/shell.d", "/home/dev/.config/agent-sandbox/shell.d", true))
+	}
+	if config.EnableDotfiles {
+		mounts = append(mounts, homeMount("AGENTBOX_ENABLE_DOTFILES", config.Home, ".config/agent-sandbox/dotfiles", "/home/dev/.dotfiles", true))
+	}
+	if config.MountGitReadonly {
+		mounts = append(mounts, workspaceMount("AGENTBOX_MOUNT_GIT_READONLY", repoRoot, ".git", false))
+	}
+	if config.MountIdeaReadonly {
+		mounts = append(mounts, workspaceMount("AGENTBOX_MOUNT_IDEA_READONLY", repoRoot, ".idea", true))
+	}
+	if config.MountVSCodeReadonly {
+		mounts = append(mounts, workspaceMount("AGENTBOX_MOUNT_VSCODE_READONLY", repoRoot, ".vscode", true))
+	}
+
+	return mounts
+}
+
+// optionalAgentMounts lists the opt-in mounts for one agent's override file.
+func optionalAgentMounts(agent string, config EnvConfig) []optionalMount {
+	if agent != "claude" || !config.MountClaudeConfig {
+		return nil
+	}
+
+	return []optionalMount{
+		homeMount("AGENTBOX_MOUNT_CLAUDE_CONFIG", config.Home, ".claude/CLAUDE.md", "/home/dev/.claude/CLAUDE.md", false),
+		homeMount("AGENTBOX_MOUNT_CLAUDE_CONFIG", config.Home, ".claude/settings.json", "/home/dev/.claude/settings.json", false),
+	}
+}
+
+// prepareOptionalMount creates an agentbox-named directory when it is missing
+// and checks that a user-named path exists. It returns false when the mount
+// should be skipped. An unresolved host path is left to docker compose.
+func prepareOptionalMount(mount optionalMount, warn io.Writer) (bool, error) {
+	if mount.hostPath == "" {
+		return true, nil
+	}
+	if mount.create {
+		return true, os.MkdirAll(mount.hostPath, 0o755)
+	}
+
+	_, err := os.Stat(mount.hostPath)
+	if err == nil {
+		return true, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	fmt.Fprintf(warn, "Skipping mount of %s: %s does not exist (%s=true). Create it and rerun, or add the mount to the override file by hand.\n", mount.target, mount.hostPath, mount.flag)
+	return false, nil
+}

--- a/internal/scaffold/optional_mounts.go
+++ b/internal/scaffold/optional_mounts.go
@@ -24,6 +24,11 @@ type optionalMount struct {
 	// missing. User-named paths are never created; a missing one skips the
 	// mount instead of letting Docker replace it with an empty directory.
 	create bool
+	// wantFile is true when the host path must be a regular file. A
+	// directory at that path, such as one Docker created before agentbox
+	// disabled host path creation, would be mounted over a file target and
+	// break the tool that reads it.
+	wantFile bool
 }
 
 func homeMount(flag string, home string, relative string, target string, create bool) optionalMount {
@@ -31,6 +36,12 @@ func homeMount(flag string, home string, relative string, target string, create 
 	if home != "" {
 		mount.hostPath = filepath.Join(home, filepath.FromSlash(relative))
 	}
+	return mount
+}
+
+func homeFileMount(flag string, home string, relative string, target string) optionalMount {
+	mount := homeMount(flag, home, relative, target, false)
+	mount.wantFile = true
 	return mount
 }
 
@@ -73,29 +84,41 @@ func optionalAgentMounts(agent string, config EnvConfig) []optionalMount {
 	}
 
 	return []optionalMount{
-		homeMount("AGENTBOX_MOUNT_CLAUDE_CONFIG", config.Home, ".claude/CLAUDE.md", "/home/dev/.claude/CLAUDE.md", false),
-		homeMount("AGENTBOX_MOUNT_CLAUDE_CONFIG", config.Home, ".claude/settings.json", "/home/dev/.claude/settings.json", false),
+		homeFileMount("AGENTBOX_MOUNT_CLAUDE_CONFIG", config.Home, ".claude/CLAUDE.md", "/home/dev/.claude/CLAUDE.md"),
+		homeFileMount("AGENTBOX_MOUNT_CLAUDE_CONFIG", config.Home, ".claude/settings.json", "/home/dev/.claude/settings.json"),
 	}
 }
 
 // prepareOptionalMount creates an agentbox-named directory when it is missing
-// and checks that a user-named path exists. It returns false when the mount
-// should be skipped. An unresolved host path is left to docker compose.
+// and checks that a user-named path exists with the expected type. It returns
+// false when the mount should be skipped. An unresolved host path is left to
+// docker compose.
 func prepareOptionalMount(mount optionalMount, warn io.Writer) (bool, error) {
 	if mount.hostPath == "" {
 		return true, nil
 	}
 	if mount.create {
-		return true, os.MkdirAll(mount.hostPath, 0o755)
-	}
-
-	_, err := os.Stat(mount.hostPath)
-	if err == nil {
+		if err := os.MkdirAll(mount.hostPath, 0o755); err != nil {
+			return false, fmt.Errorf("create %s for %s: %w", mount.hostPath, mount.flag, err)
+		}
 		return true, nil
 	}
-	if !errors.Is(err, os.ErrNotExist) {
+
+	info, err := os.Stat(mount.hostPath)
+	if errors.Is(err, os.ErrNotExist) {
+		skipOptionalMount(warn, mount, "does not exist")
+		return false, nil
+	}
+	if err != nil {
 		return false, err
 	}
-	fmt.Fprintf(warn, "Skipping mount of %s: %s does not exist (%s=true). Create it and rerun, or add the mount to the override file by hand.\n", mount.target, mount.hostPath, mount.flag)
-	return false, nil
+	if mount.wantFile && !info.Mode().IsRegular() {
+		skipOptionalMount(warn, mount, "is not a regular file")
+		return false, nil
+	}
+	return true, nil
+}
+
+func skipOptionalMount(warn io.Writer, mount optionalMount, reason string) {
+	fmt.Fprintf(warn, "Skipping mount of %s: %s %s (%s=true). Fix the path and rerun, or add the mount to the override file by hand.\n", mount.target, mount.hostPath, reason, mount.flag)
 }

--- a/internal/scaffold/sync.go
+++ b/internal/scaffold/sync.go
@@ -39,7 +39,7 @@ func EnsureCLIAgentRuntimeFiles(ctx context.Context, params SyncParams) (runtime
 	if err := ensureCLIBasePolicyRuntimeConfigIfExists(params.RepoRoot); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
-	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserOverrideFile(params.RepoRoot), "compose/user.override.yml", optionalSharedVolumes(env)); err != nil {
+	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserOverrideFile(params.RepoRoot), "compose/user.override.yml", optionalSharedMounts(params.RepoRoot, env), params.Stderr); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
 	if err := scaffoldUserPolicyFileIfMissing(runtime.SharedPolicyFile(params.RepoRoot), "user.policy.yaml"); err != nil {
@@ -63,7 +63,7 @@ func EnsureCLIAgentRuntimeFiles(ctx context.Context, params SyncParams) (runtime
 	if err := ensureCLIAgentPolicyRuntimeConfig(params.RepoRoot, params.Agent); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
-	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserAgentOverrideFile(params.RepoRoot, params.Agent), "compose/user.agent.override.yml", optionalAgentVolumes(params.Agent, env)); err != nil {
+	if err := writeUserOverrideIfMissing(params.RepoRoot, runtime.CLIUserAgentOverrideFile(params.RepoRoot, params.Agent), "compose/user.agent.override.yml", optionalAgentMounts(params.Agent, env), params.Stderr); err != nil {
 		return runtime.ActiveTarget{}, err
 	}
 
@@ -181,9 +181,9 @@ func EnsureDevcontainerRuntimeFiles(ctx context.Context, params SyncParams) (run
 	return target, nil
 }
 
-func EnsureSharedComposeOverride(repoRoot string, lookupEnv func(string) string) error {
+func EnsureSharedComposeOverride(repoRoot string, lookupEnv func(string) string, stderr io.Writer) error {
 	env := loadEnvConfig(InitParams{LookupEnv: lookupEnv}, runtime.ModeCLI)
-	return writeUserOverrideIfMissing(repoRoot, runtime.CLIUserOverrideFile(repoRoot), "compose/user.override.yml", optionalSharedVolumes(env))
+	return writeUserOverrideIfMissing(repoRoot, runtime.CLIUserOverrideFile(repoRoot), "compose/user.override.yml", optionalSharedMounts(repoRoot, env), stderr)
 }
 
 func EnsureSharedPolicyFile(repoRoot string) error {

--- a/internal/scaffold/sync_test.go
+++ b/internal/scaffold/sync_test.go
@@ -102,13 +102,13 @@ func TestEnsureCLIAgentRuntimeFilesCreatesMissingFilesAndPersistsState(t *testin
 	assertNoProxySecretRuntime(t, agent.Services.Agent)
 
 	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
-	assertContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, `${HOME}/.config/agent-sandbox/shell.d:/home/dev/.config/agent-sandbox/shell.d:ro`)
-	assertContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, `${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro`)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/shell.d", "/home/dev/.config/agent-sandbox/shell.d", true)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/dotfiles", "/home/dev/.dotfiles", true)
 	assertNoProxySecretRuntime(t, sharedOverride.Services.Agent)
 
 	agentOverride := readCompose(t, runtime.CLIUserAgentOverrideFile(repoRoot, "claude"))
-	assertContainsVolumeString(t, agentOverride.Services.Agent.Volumes, `${HOME}/.claude/CLAUDE.md:/home/dev/.claude/CLAUDE.md:ro`)
-	assertContainsVolumeString(t, agentOverride.Services.Agent.Volumes, `${HOME}/.claude/settings.json:/home/dev/.claude/settings.json:ro`)
+	assertContainsManagedBind(t, agentOverride.Services.Agent.Volumes, "${HOME}/.claude/CLAUDE.md", "/home/dev/.claude/CLAUDE.md", true)
+	assertContainsManagedBind(t, agentOverride.Services.Agent.Volumes, "${HOME}/.claude/settings.json", "/home/dev/.claude/settings.json", true)
 	assertNoProxySecretRuntime(t, agentOverride.Services.Agent)
 
 	assertAgentboxRunAgentReadOnly(t, base, agent, sharedOverride, agentOverride)
@@ -120,7 +120,7 @@ func TestEnsureCLIAgentRuntimeFilesCreatesMissingFilesAndPersistsState(t *testin
 func TestEnsureSharedRuntimeConfigHelpersCreateExpectedFiles(t *testing.T) {
 	repoRoot := t.TempDir()
 
-	if err := EnsureSharedComposeOverride(repoRoot, mapLookup(map[string]string{"AGENTBOX_ENABLE_DOTFILES": "true"})); err != nil {
+	if err := EnsureSharedComposeOverride(repoRoot, mapLookup(map[string]string{"AGENTBOX_ENABLE_DOTFILES": "true"}), nil); err != nil {
 		t.Fatalf("EnsureSharedComposeOverride failed: %v", err)
 	}
 	if err := EnsureSharedPolicyFile(repoRoot); err != nil {
@@ -134,7 +134,7 @@ func TestEnsureSharedRuntimeConfigHelpersCreateExpectedFiles(t *testing.T) {
 	}
 
 	sharedOverride := readCompose(t, runtime.CLIUserOverrideFile(repoRoot))
-	assertContainsVolumeString(t, sharedOverride.Services.Agent.Volumes, `${HOME}/.config/agent-sandbox/dotfiles:/home/dev/.dotfiles:ro`)
+	assertContainsManagedBind(t, sharedOverride.Services.Agent.Volumes, "${HOME}/.config/agent-sandbox/dotfiles", "/home/dev/.dotfiles", true)
 	assertFileExists(t, runtime.SharedPolicyFile(repoRoot))
 	assertFileExists(t, runtime.UserAgentPolicyFile(repoRoot, "claude"))
 }


### PR DESCRIPTION
## Summary

Stacked on #192. Applies the same rule to the opt-in `AGENTBOX_*` mounts: agentbox creates every directory it names, never creates a path the user named, and never lets Docker create anything.

Today those mounts are seeded into the user-owned override scaffolds in short compose syntax, which implies `create_host_path: true`. When the host path is missing, Docker creates it:

| Mount | Flag | What Docker created |
|---|---|---|
| `~/.config/agent-sandbox/shell.d`, `dotfiles` | `AGENTBOX_ENABLE_*` | root-owned directory on Linux hosts |
| `.idea/`, `.vscode/` (CLI mode) | `AGENTBOX_MOUNT_*_READONLY` | root-owned directory on Linux hosts |
| `.git/` | `AGENTBOX_MOUNT_GIT_READONLY` | an empty `.git/` in a non-repository |
| `~/.claude/CLAUDE.md`, `settings.json` | `AGENTBOX_MOUNT_CLAUDE_CONFIG` | directories with those names, breaking Claude Code on the host |

## Change

- New `internal/scaffold/optional_mounts.go` describes each opt-in mount with its compose source, container target, resolved host path, and whether agentbox owns the name.
- `writeUserOverrideIfMissing` now creates agentbox-named directories when missing, skips user-named paths that do not exist with a warning on stderr, and writes every mount in long form with `create_host_path: false`. It only runs when the override file is first scaffolded, so existing user-owned files are untouched.
- `HOME` comes from the injected env lookup, the same source docker compose expands `${HOME}` from. When it is unknown, `${HOME}` mounts are written unchanged and left to compose.
- `EnsureSharedComposeOverride` gains a stderr writer so `agentbox edit compose` shows the same warnings.
- Override template comments and `docs/dotfiles.md` show the long form; `docs/cli.md` documents the rule.

Warning text when a user-named path is missing:

```
Skipping mount of /workspace/.git: /path/to/project/.git does not exist (AGENTBOX_MOUNT_GIT_READONLY=true). Create it and rerun, or add the mount to the override file by hand.
```

## Tests

- The representative Claude scaffold test now pre-creates the user-named paths, asserts every opt-in mount in long form, and asserts the agentbox-named directories were created under `HOME` and the repo root.
- `TestInitializeCLISkipsMissingUserNamedMounts` asserts `.git/` and the Claude files are neither mounted nor created and that each skip is reported on stderr.
- `TestInitializeCLIKeepsHomeMountsWhenHomeIsUnknown` asserts `${HOME}` mounts survive without `HOME`.
- Sync tests updated for the long form and the new `EnsureSharedComposeOverride` signature.

`go test ./...`, `go vet ./...`, and `gofmt -l` are clean.

## Merge order

Merge #192 first, then rebase this branch onto main. The branch is a fast-forward of #192 plus one commit.
