### PR TITLE
Set NODE_EXTRA_CA_CERTS in the base image environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **VS Code Server trusts the proxy CA.** The base image now sets `NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt` in the image environment instead of exporting it from the sandbox shell. The IDE starts the VS Code Server and its extension host through `docker exec` without a login shell, so they never saw the shell export and logged `unable to verify the first certificate` for marketplace metadata, telemetry, and extension downloads through the proxy. Requires rebuilt images (`agentbox bump`); for older images, set the variable on the agent service in `user.override.yml`.
+
 ## [0.17.1] - 2026-09-06
 
 First-run fixes for devcontainer mode and the proxy secret directory, and opt-in mounts that never let Docker create host paths.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,6 +84,29 @@ mkdir -p .vscode   # or .idea for JetBrains
 
 Running `agentbox switch --agent <agent>` also recreates it.
 
+## VS Code Server logs "unable to verify the first certificate"
+
+In devcontainer mode the Dev Containers log shows lines like:
+
+```text
+https://main.vscode-cdn.net/extensions/marketplace.json - error GET unable to verify the first certificate
+```
+
+The VS Code Server runs on Node.js, which ignores the system trust store. The IDE starts the server through
+`docker exec` without a login shell, so a shell-level `NODE_EXTRA_CA_CERTS` export never reaches it. Marketplace
+metadata and telemetry fail, and installing an extension inside the container fails unless it is already cached.
+
+Base images built after this fix set `NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt` in the image environment; run
+`agentbox bump` to pin them. For older images, set it on the agent service in
+`.agent-sandbox/compose/user.override.yml` and rebuild the container:
+
+```yaml
+services:
+  agent:
+    environment:
+      NODE_EXTRA_CA_CERTS: /etc/mitmproxy/ca.crt
+```
+
 ## Proxy fails to inject a header (missing or unreadable secret file)
 
 A rule with `transform.request.headers` (or a GitHub `git.auth.secret`) requires the proxy to resolve the named secret at request time. If the file is missing or unreadable, the request is blocked before reaching the upstream and the proxy emits a structured rejection event:

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -136,6 +136,17 @@ ENV LANG=C.utf8
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
+# Node.js bundles its own root store and ignores the system bundle. Point it
+# at the mitmproxy CA mounted from the proxy at container start. This must be
+# image environment rather than a shell export: the IDE launches the VS Code
+# Server and its extension host through `docker exec` without a login shell,
+# so they inherit only what is baked into the container config. The raw CA
+# file is used instead of the system bundle because the bundle is regenerated
+# by entrypoint.sh, and the IDE can start its server before that completes.
+# The file does not exist at image build time, so Node prints a harmless
+# "Ignoring extra certs" warning during npm installs in derived images.
+ENV NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt
+
 # Create minimal .zshrc - users can mount their own dotfiles for customization
 COPY --chown=${USERNAME}:${USERNAME} zshrc /home/${USERNAME}/.zshrc
 COPY --chown=${USERNAME}:${USERNAME} tmux.conf /home/${USERNAME}/.tmux.conf

--- a/images/base/shell-init.sh
+++ b/images/base/shell-init.sh
@@ -1,12 +1,6 @@
 # Agent Sandbox shell initialization
 # Sourced from /etc/zsh/zshrc (system-level, runs before ~/.zshrc)
 
-# Node.js ignores the system trust store and bundles its own CAs.
-# Tell it to also trust the proxy CA so HTTPS works through mitmproxy.
-if [ -f /etc/mitmproxy/ca.crt ]; then
-  export NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt
-fi
-
 # Source generated fake credential-shim initialization when the proxy configured one.
 CREDENTIAL_SHIM_INIT="${AGENTBOX_CREDENTIAL_SHIM_INIT_PATH:-/run/agentbox/credential-shims/init.zsh}"
 if [ -f "$CREDENTIAL_SHIM_INIT" ]; then


### PR DESCRIPTION
## Summary

In devcontainer mode the VS Code Server inside the container logs:

```
https://main.vscode-cdn.net/extensions/marketplace.json - error GET unable to verify the first certificate
https://mobile.events.data.microsoft.com/OneCollector/1.0 - error POST unable to verify the first certificate
```

The proxy CA reaches Node.js only through an export in `images/base/shell-init.sh`, which zsh sources. The IDE launches the server through `docker exec` via `/bin/sh` with `--force-disable-user-env`, so the server never sees it. Python and curl are fine because the Dockerfile sets their CA variables as image environment. The Node one was never promoted. Dates to a1c6844 (March).

Impact: marketplace metadata and telemetry fail, and installing an extension inside the container fails unless the shared `/vscode` volume already caches it. A first-time Copilot devcontainer user on a clean machine ends up without the Copilot Chat extension.

## Change

- `images/base/Dockerfile`: `ENV NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt`, next to the existing `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` lines, with a comment on why it is image environment and why it points at the mounted file.
- `images/base/shell-init.sh`: drop the now-redundant conditional export.
- `docs/troubleshooting.md`: new entry with the log signature and the user-override workaround for older images.
- `CHANGELOG.md`: Unreleased / Fixed entry.

## Why the mounted file and not the system bundle

The bundle at `/etc/ssl/certs/ca-certificates.crt` only contains the proxy CA after `entrypoint.sh` runs `update-ca-certificates`. The Dev Containers extension starts the server about two seconds after the container starts, which can race that step. The mounted CA file is present from container creation because the proxy is healthy before the agent starts. The cost is a harmless "Ignoring extra certs ... load failed" warning from Node during `npm install` in derived image builds, since the file does not exist at build time.

## Verification

Set the same variable on the agent service in `.agent-sandbox/compose/user.override.yml` of a Copilot devcontainer project and rebuilt the container. The certificate errors no longer appear; the server, extension host, and Agent Host start normally. The Dockerfile change is the same environment delivered by the image instead of the override.

No Go or proxy code changes. The fix reaches users when the base and agent images are rebuilt and pinned with `agentbox bump`.
