### PR TITLE
Document that Copilot in VS Code runs inside the sandbox

### DIFF
--- a/docs/agents/copilot.md
+++ b/docs/agents/copilot.md
@@ -1,6 +1,6 @@
-# GitHub Copilot CLI Sandbox Template
+# GitHub Copilot Sandbox Template
 
-Run GitHub Copilot CLI in a network-locked container. All outbound traffic is routed through an enforcing proxy that applies the project's network policy.
+Run GitHub Copilot CLI, or the Copilot VS Code extension in devcontainer mode, in a network-locked container. All outbound traffic is routed through an enforcing proxy that applies the project's network policy.
 
 See the [main README](../../README.md) for installation, architecture overview, and configuration options.
 
@@ -36,6 +36,18 @@ Afterward, for CLI mode, stop the container:
 ```bash
 agentbox compose down
 ```
+
+### Use Copilot in VS Code
+
+In devcontainer mode the Copilot Chat extension runs in the container's extension host, and VS Code starts the
+Agent Host that powers Copilot sessions inside the container as well. Both the chat view and "New Copilot CLI
+Session" therefore execute in the sandbox: tool calls, terminal commands, and model traffic go through the proxy
+exactly as the CLI does.
+
+The Agents window is not supported. VS Code cannot target a Dev Container from it
+([microsoft/vscode#317380](https://github.com/microsoft/vscode/issues/317380)), and its remote path requires SSH or a
+dev tunnel, both of which the sandbox blocks by design. Use the chat view or a CLI session from the Dev Container
+window instead.
 
 ## Network policy and the GitHub API
 


### PR DESCRIPTION
## Summary

`docs/agents/copilot.md` was titled and written as a CLI-only guide, which is how #163 (SANDBOX-58) came to ask for "VS Code Copilot GUI support" that already exists in devcontainer mode.

Verified manually in a Dev Container window: the Copilot Chat extension runs in the container's extension host, VS Code starts its Agent Host inside the container (visible in the Dev Containers log as `ServerAgentHostManager: agent host started`), and both the chat view and "New Copilot CLI Session" execute in the sandbox with tool calls, terminal commands, and model traffic going through the proxy.

## Change

- Retitle the doc and widen the intro so it covers the VS Code extension in devcontainer mode.
- Add a "Use Copilot in VS Code" section stating what runs inside the sandbox.
- State that the Agents window is not supported: VS Code cannot target a Dev Container from it (microsoft/vscode#317380), and its remote path needs SSH or a dev tunnel, which the sandbox blocks by design.

Docs only. The README support matrix is unchanged; Copilot in VS Code stays Preview.

Related: #195 fixes the VS Code Server certificate errors seen in the same test.
