### PR TITLE
Document the release procedure and PR conventions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,8 @@ image build reaches users through the next push-triggered build and `agentbox bu
   requires a force-push of the PR branch. Ask the maintainer before any force-push and use `--force-with-lease`.
 - Never amend a pushed commit. Address review feedback in new commits.
 - Every PR gets an automated Greptile review. Evaluate each comment, fix the valid ones in a new commit, and reply on
-  the thread with the commit and the test that covers it.
+  the thread with the commit and the test that covers it. Then post a PR comment containing `@greptile review` so the
+  new commit gets a fresh review.
 
 ## Adding A New Agent
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,29 @@ Per-agent version check workflows exist for:
 - `opencode`
 - `pi`
 
+### Cutting a release
+
+1. Open a PR that moves the `[Unreleased]` entries in `CHANGELOG.md` under `## [X.Y.Z] - YYYY-MM-DD` with a one-line
+   summary, keeps an empty `[Unreleased]` section on top, and bumps the `--version vX.Y.Z` examples in `README.md` and
+   `scripts/install-agentbox.sh`.
+2. After it merges, push a lightweight tag `vX.Y.Z` on the merge commit. `release-go-binaries.yml` builds the archives
+   and opens a draft GitHub release with generated notes.
+3. The maintainer publishes the draft and edits the notes. Publishing is outside the sandbox proxy's write allowlist, so
+   an agent stops after reporting the draft release URL.
+
+`build-images.yml` runs on pushes to `main` that touch `images/` and on release events. A fix merged after a release's
+image build reaches users through the next push-triggered build and `agentbox bump`.
+
+## Pull Requests
+
+- Open agent-authored PRs as drafts with `gh api -X POST repos/{owner}/{repo}/pulls`. The `gh pr` commands are blocked
+  in the sandbox; see `docs/github.md`.
+- PRs are rebase-merged. A PR stacked on another branch needs `git rebase origin/main` after its base lands, which
+  requires a force-push of the PR branch. Ask the maintainer before any force-push and use `--force-with-lease`.
+- Never amend a pushed commit. Address review feedback in new commits.
+- Every PR gets an automated Greptile review. Evaluate each comment, fix the valid ones in a new commit, and reply on
+  the thread with the commit and the test that covers it.
+
 ## Adding A New Agent
 
 Use the `add-agent` skill or follow an existing agent end to end.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,8 +237,8 @@ image build reaches users through the next push-triggered build and `agentbox bu
 
 ## Pull Requests
 
-- Open agent-authored PRs as drafts with `gh api -X POST repos/{owner}/{repo}/pulls`. The `gh pr` commands are blocked
-  in the sandbox; see `docs/github.md`.
+- Open agent-authored PRs as drafts with `gh api -X POST repos/{owner}/{repo}/pulls -F draft=true`. The `gh pr`
+  commands are blocked in the sandbox; see `docs/github.md`.
 - PRs are rebase-merged. A PR stacked on another branch needs `git rebase origin/main` after its base lands, which
   requires a force-push of the PR branch. Ask the maintainer before any force-push and use `--force-with-lease`.
 - Never amend a pushed commit. Address review feedback in new commits.

--- a/docs/github.md
+++ b/docs/github.md
@@ -106,7 +106,7 @@ rule matches first, so a repo-scoped `api.auth` entry neither narrows anything n
 
 ```bash
 gh api 'repos/{owner}/{repo}/issues?state=open' --jq '.[] | "#\(.number) \(.title)"'
-gh api -X POST 'repos/{owner}/{repo}/pulls' -f title='Title' -f head=my-branch -f base=main -f body='Body'
+gh api -X POST 'repos/{owner}/{repo}/pulls' -F draft=true -f title='Title' -f head=my-branch -f base=main -f body='Body'
 gh api "repos/{owner}/{repo}/commits/$(git rev-parse HEAD)/check-runs" --jq '.check_runs[] | "\(.name): \(.conclusion)"'
 ```
 

--- a/images/base/skills/operating-in-agent-sandbox/github-api.md
+++ b/images/base/skills/operating-in-agent-sandbox/github-api.md
@@ -43,7 +43,7 @@ gh api 'repos/{owner}/{repo}/pulls/45' --jq '{title, state, mergeable, head: .he
 gh api 'repos/{owner}/{repo}/pulls/45/files' --jq '.[] | "\(.status) \(.filename) +\(.additions) -\(.deletions)"'
 gh api 'repos/{owner}/{repo}/pulls/45/reviews' --jq '.[] | "\(.user.login): \(.state)"'
 gh api 'repos/{owner}/{repo}/pulls/45/comments' --jq '.[] | "\(.path):\(.line) \(.body)"'
-gh api -X POST 'repos/{owner}/{repo}/pulls' -f title='Title' -f head=my-branch -f base=main -f body='Body'
+gh api -X POST 'repos/{owner}/{repo}/pulls' -F draft=true -f title='Title' -f head=my-branch -f base=main -f body='Body'
 
 # CI status for a commit
 gh api "repos/{owner}/{repo}/commits/$(git rev-parse HEAD)/check-runs" \


### PR DESCRIPTION
## Summary

The release procedure and the PR conventions were not written down anywhere in the repo. Both had to be reconstructed from the 0.17.0 commits and the workflow files while cutting 0.17.1. This moves them into `AGENTS.md`, which `CLAUDE.md` symlinks to, so every agent and contributor sees them.

## Change

- **CI And Release** gains a "Cutting a release" subsection: the changelog PR shape, the lightweight tag on the merge commit that triggers `release-go-binaries.yml`, and that the maintainer publishes the CI-created draft (publishing is outside the sandbox proxy's write allowlist). Notes that `build-images.yml` runs on pushes to `main` touching `images/` and on release events, so a fix merged after a release's image build reaches users via the next push build and `agentbox bump`.
- New **Pull Requests** section: draft PRs through `gh api` (the `gh pr` commands are blocked in the sandbox), rebase-merge and the ask-before-force-push rule for stacked PRs, no amending after push, and how to handle Greptile review comments.

Docs only.
