### PR TITLE
Install codex-code-mode-host alongside the Codex binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Codex no longer warns that Code Mode is unavailable.** The codex image installed only the `codex` binary from the GitHub release, but Codex looks for the separate `codex-code-mode-host` helper next to its own executable and logged `Code Mode is unavailable because failed to spawn code-mode host ... host executable was not found` on every session. The image now installs both binaries from the same release into `~/.local/bin`. A release that does not publish the host asset builds with a warning instead of failing. Requires rebuilt images (`agentbox bump`).
 - **VS Code Server trusts the proxy CA.** The base image now sets `NODE_EXTRA_CA_CERTS=/etc/mitmproxy/ca.crt` in the image environment instead of exporting it from the sandbox shell. The IDE starts the VS Code Server and its extension host through `docker exec` without a login shell, so they never saw the shell export and logged `unable to verify the first certificate` for marketplace metadata, telemetry, and extension downloads through the proxy. Requires rebuilt images (`agentbox bump`); for older images, set the variable on the agent service in `user.override.yml`.
 
 ## [0.17.1] - 2026-09-06

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -30,7 +30,7 @@ codex
 codex --full-auto
 ```
 
-The image includes system `bubblewrap` so Codex's Linux startup check finds `/usr/bin/bwrap` and does not warn at launch. Codex still defaults to `danger-full-access` via the baked-in config, with isolation handled by the surrounding container, proxy, and firewall.
+The image includes system `bubblewrap` so Codex's Linux startup check finds `/usr/bin/bwrap` and does not warn at launch. It also installs the `codex-code-mode-host` helper next to the `codex` binary in `~/.local/bin` so Code Mode is available. Codex still defaults to `danger-full-access` via the baked-in config, with isolation handled by the surrounding container, proxy, and firewall.
 
 Afterward, for CLI mode, stop the container:
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -30,7 +30,7 @@ codex
 codex --full-auto
 ```
 
-The image includes system `bubblewrap` so Codex's Linux startup check finds `/usr/bin/bwrap` and does not warn at launch. It also installs the `codex-code-mode-host` helper next to the `codex` binary in `~/.local/bin` so Code Mode is available. Codex still defaults to `danger-full-access` via the baked-in config, with isolation handled by the surrounding container, proxy, and firewall.
+The image includes system `bubblewrap` so Codex's Linux startup check finds `/usr/bin/bwrap` and does not warn at launch. When the selected Codex release publishes the `codex-code-mode-host` helper, the image installs it next to the `codex` binary in `~/.local/bin` so Code Mode is available. Older releases without the helper asset still build, but Code Mode remains unavailable. Codex still defaults to `danger-full-access` via the baked-in config, with isolation handled by the surrounding container, proxy, and firewall.
 
 Afterward, for CLI mode, stop the container:
 

--- a/images/agents/codex/Dockerfile
+++ b/images/agents/codex/Dockerfile
@@ -34,8 +34,14 @@ ENV PATH="/home/dev/.local/bin:$PATH"
 # Tell Codex where its config/state lives
 ENV CODEX_HOME="/home/dev/.codex"
 
-# Install Codex CLI binary from GitHub releases
+# Install Codex CLI binaries from GitHub releases
 # CODEX_VERSION: "latest" or a specific version like "0.104.0"
+#
+# Codex ships as separate per-binary archives. The main `codex` binary is
+# required. `codex-code-mode-host` is the Code Mode helper that Codex looks for
+# next to its own executable; without it every session warns that Code Mode is
+# unavailable. Releases before it existed simply do not publish the asset, so a
+# 404 for the host is tolerated with a warning while any other failure aborts.
 ARG CODEX_VERSION=latest
 ARG TARGETARCH
 RUN set -e && \
@@ -44,18 +50,30 @@ RUN set -e && \
       arm64) TRIPLE="aarch64-unknown-linux-musl" ;; \
       *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
     esac && \
-    ASSET="codex-${TRIPLE}.tar.gz" && \
     if [ "$CODEX_VERSION" = "latest" ]; then \
-      URL="https://github.com/openai/codex/releases/latest/download/${ASSET}"; \
+      BASE_URL="https://github.com/openai/codex/releases/latest/download"; \
     else \
-      URL="https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/${ASSET}"; \
+      BASE_URL="https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}"; \
     fi && \
-    echo "Downloading Codex from ${URL}..." && \
-    curl -fsSL "$URL" -o /tmp/codex.tar.gz && \
-    tar -xzf /tmp/codex.tar.gz -C /tmp && \
-    mv "/tmp/codex-${TRIPLE}" /home/dev/.local/bin/codex && \
-    chmod +x /home/dev/.local/bin/codex && \
-    rm /tmp/codex.tar.gz && \
+    for BIN in codex codex-code-mode-host; do \
+      ASSET="${BIN}-${TRIPLE}.tar.gz" && \
+      URL="${BASE_URL}/${ASSET}" && \
+      echo "Downloading ${BIN} from ${URL}..." && \
+      STATUS=$(curl -sSL -w '%{http_code}' -o "/tmp/${ASSET}" "$URL") && \
+      if [ "$STATUS" != "200" ]; then \
+        rm -f "/tmp/${ASSET}"; \
+        if [ "$BIN" != "codex" ] && [ "$STATUS" = "404" ]; then \
+          echo "WARNING: ${ASSET} not published for this release (HTTP 404); skipping ${BIN}" >&2; \
+          continue; \
+        fi; \
+        echo "ERROR: failed to download ${URL} (HTTP ${STATUS})" >&2; \
+        exit 1; \
+      fi && \
+      tar -xzf "/tmp/${ASSET}" -C /tmp && \
+      mv "/tmp/${BIN}-${TRIPLE}" "/home/dev/.local/bin/${BIN}" && \
+      chmod +x "/home/dev/.local/bin/${BIN}" && \
+      rm "/tmp/${ASSET}"; \
+    done && \
     codex --version
 
 LABEL org.opencontainers.image.description="Agent Sandbox with OpenAI Codex CLI"


### PR DESCRIPTION
## Summary

The codex image installed only the `codex` binary from the GitHub release. Codex resolves the Code Mode helper `codex-code-mode-host` as a sibling of its own executable (see `codex-rs/install-context`), so every session logged:

```
Code Mode is unavailable because failed to spawn code-mode host /home/dev/.local/bin/codex-code-mode-host: host executable was not found. Code mode will fail closed; enable `features.code_mode_host` and install `codex-code-mode-host`.
```

Upstream publishes the helper as a separate per-binary archive, `codex-code-mode-host-<triple>.tar.gz`, alongside `codex-<triple>.tar.gz`.

## Changes

- `images/agents/codex/Dockerfile` downloads both archives from the same release into `~/.local/bin`. A 404 for the host asset logs a warning and continues so older `CODEX_VERSION` pins still build. A missing `codex` asset or any non-404 failure still aborts.
- `CHANGELOG.md` entry under Unreleased > Fixed.
- `docs/agents/codex.md` mentions the helper.

## Testing

- The download loop was exercised against a local fake release server for three cases: both assets present, host asset missing (warns and continues), and codex asset missing (build fails). All behaved as intended.
- Asset naming confirmed from the upstream `rust-release.yml` at tag `rust-v0.154.0`.
- Not yet built with Docker; the sandbox has no Docker and blocks github.com release downloads. Please run `CODEX_VERSION=0.154.0 ./images/build.sh codex` on the host and start `codex` to confirm the warning is gone.
