### PR TITLE
Plan m18: DNS egress controls

### DIFF
--- a/docs/plan/decisions/006-credential-shim-is-renderer-owned.md
+++ b/docs/plan/decisions/006-credential-shim-is-renderer-owned.md
@@ -80,8 +80,8 @@ read only at request time inside the proxy.
 
 - The shim-and-replace pairing cannot be partially configured. Either both halves are present
   in the rendered policy or neither.
-- Future credential-injection work (provider API keys in `m18`, GitHub REST APIs in `m17`, and host credential helpers
-  in `m20`) can define new shim kinds without adopting a generic env-export surface that would be hard to constrain.
+- Future credential-injection work (provider API keys in `m19`, GitHub REST APIs in `m17`, and host credential helpers
+  in `m21`) can define new shim kinds without adopting a generic env-export surface that would be hard to constrain.
 - Rendered policy stays small. The `credential_shim` block only appears when something needs
   it, and the payload's only consumer is `/etc/agent-sandbox/shell-init.sh`.
 

--- a/docs/plan/decisions/007-stock-gh-api-over-rest-wrapper.md
+++ b/docs/plan/decisions/007-stock-gh-api-over-rest-wrapper.md
@@ -15,7 +15,7 @@ While reviewing sandbox GitHub access on 2026-09-05, two things changed the calc
 
 - `gh api` already is a REST-only client with repo identity in the URL path. It supports `{owner}/{repo}`
   placeholders, `--jq`, `--paginate`, and typed fields, and agents know it well.
-- The `m15` injection layer already supports `bearer` transforms and the renderer-owned shim model, and the `m18` plan
+- The `m15` injection layer already supports `bearer` transforms and the renderer-owned shim model, and the `m19` plan
   already describes a generic env shim primitive. A `GH_TOKEN` shim is the same primitive with a different variable
   name.
 
@@ -59,7 +59,7 @@ Alternatives considered:
 **Positive:**
 
 - No new binary, release pipeline, or command surface to maintain
-- Reuses `m14` rules, `m15` injection, and the `m18` shim shape
+- Reuses `m14` rules, `m15` injection, and the `m19` shim shape
 - Repo scoping is enforced at the proxy and can be tightened further with authored rules
 
 **Negative:**

--- a/docs/plan/learnings.md
+++ b/docs/plan/learnings.md
@@ -9,7 +9,7 @@ Lessons learned during project execution. Review at the start of each planning s
 - VS Code devcontainers need `--cap-add=NET_ADMIN` and `--cap-add=NET_RAW` for iptables to work
 - Policy schema should nest by concern (`egress:`, future `ingress:`, `mounts:`) for extensibility
 - `yq` will be needed to parse YAML in the firewall script
-- VS Code devcontainers bypass Docker ENTRYPOINT; use `postStartCommand` for runtime initialization that must run every container start
+- VS Code devcontainers replace the container command by default; set `overrideCommand: false` so the image entrypoint runs instead of duplicating runtime initialization in `postStartCommand`
 - Entrypoint scripts should be idempotent (check for existing state before acting) to support both devcontainer and compose workflows
 - devcontainer.json and docker-compose.yml need separate volume/mount configs; they serve different workflows and VS Code reads devcontainer.json directly
 - yq syntax `.foo // [] | .[]` safely iterates arrays that may be missing or null

--- a/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
+++ b/docs/plan/milestones/m14-fine-grained-proxy/milestone.md
@@ -23,7 +23,7 @@ request-aware rules, semantic GitHub service expansion, hot reload, integration 
 **Excluded:**
 - Secret injection, header substitution, or other credential features from `m15`
 - GitHub API access work from `m17`
-- Monitoring UI or interactive unblock workflows from `m19`
+- Monitoring UI or interactive unblock workflows from `m20`
 - Non-HTTP protocols
 - Header matching and request body inspection. For now, a matched URL rule implies the endpoint is trusted to receive
   the full request.

--- a/docs/plan/milestones/m15-proxy-secret-injection/milestone.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/milestone.md
@@ -35,11 +35,11 @@ to hold the real secret.
 - Request body mutation
 - Request, response, header, or URL scanning for leaked secret values
 - Replacing every credential flow with proxy injection
-- A full host credential helper service; that remains `m20`
+- A full host credential helper service; that remains `m21`
 - macOS Keychain-backed secret resolution; m15 should preserve the extension point but ship file-backed storage first
 - A complete secret-management CLI with project, target, and session scoped storage
 - A new live-update control plane beyond the existing policy reload path
-- Provider API-key injection; that moves to `m18`
+- Provider API-key injection; that moves to `m19`
 - GitHub API access work; that moves to `m17`
 
 ## Design

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/execution-log.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/execution-log.md
@@ -71,7 +71,7 @@ with surface-scoped GitHub mappings. The preferred policy shape is now `git.acce
 `readonly` for unauthenticated GitHub repo-scoped policies, but that compatibility path was removed after confirming the
 syntax had not shipped.
 
-**Decision:** `api.auth` is reserved and rejected in m15.5. Provider API-key behavior belongs to `m18`, and GitHub API
+**Decision:** `api.auth` is reserved and rejected in m15.5. Provider API-key behavior belongs to `m19`, and GitHub API
 access behavior belongs to `m17`.
 
 ## 2026-05-07 04:00 UTC - Initial task plan

--- a/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/task.md
+++ b/docs/plan/milestones/m15-proxy-secret-injection/tasks/m15.5-service-catalog-auth/task.md
@@ -146,7 +146,7 @@ services:
         secret: github.agent-sandbox.push-token
 ```
 
-Reject `api.auth` for now with a clear reserved/unsupported error. Provider API-key injection belongs to `m18`, GitHub
+Reject `api.auth` for now with a clear reserved/unsupported error. Provider API-key injection belongs to `m19`, GitHub
 API access behavior belongs to `m17`, and M15.5 should not imply API credential injection.
 
 For authenticated Git rules, emit the same canonical rule-scoped transform shape as explicit `domains[].transform`

--- a/docs/plan/milestones/m16-hermes/milestone.md
+++ b/docs/plan/milestones/m16-hermes/milestone.md
@@ -23,7 +23,7 @@ in Agent Sandbox. Users can initialize, run, and switch to Hermes via the standa
   add the relevant provider service (`claude`, `codex`, `openai`, `gemini`, `openrouter`) to their policy themselves.
 - Hermes's self-improving "skills" persistence semantics beyond mounting the appropriate state volume so learned skills
   survive container restarts.
-- Proxy-side credential injection for any provider Hermes calls. That work belongs to m18 (provider API-key injection)
+- Proxy-side credential injection for any provider Hermes calls. That work belongs to m19 (provider API-key injection)
   and is not gated on this milestone.
 
 ## Applicable Learnings

--- a/docs/plan/milestones/m17-github-api-access/milestone.md
+++ b/docs/plan/milestones/m17-github-api-access/milestone.md
@@ -103,7 +103,7 @@ Excluded:
   every endpoint outside those two families
 - Emit a `bearer` transform on every api rule when `api.auth.secret` is set; default to `on_existing_header: fail`
 - Support `api.auth.client_shim` with a generic `env` kind whose variable name is chosen by the catalog, here
-  `GH_TOKEN`. This is the primitive `m18.4` later extends to provider API keys, so keep the hint shape generic
+  `GH_TOKEN`. This is the primitive `m19.4` later extends to provider API keys, so keep the hint shape generic
 - Switch api rules to `on_existing_header: replace` only when the shim is present
 - Extend the shell-init consumer so the rendered hint exports `GH_TOKEN` with the placeholder value
 - Keep the sanitized `/run/agentbox/policy.yaml` free of transforms and secret IDs, as today
@@ -239,7 +239,7 @@ the result into the documented table.
 2. `m17.3` needs both. Do not write instructions before the matrix exists.
 3. `m17.4` and `m17.5` follow from `m17.3` and can run in parallel.
 
-`m17.2` builds the env shim primitive in the generic shape `m18.4` describes. `m18` reuses it rather than building a
+`m17.2` builds the env shim primitive in the generic shape `m19.4` describes. `m19` reuses it rather than building a
 second one.
 
 ## Risks

--- a/docs/plan/milestones/m17-github-api-access/tasks/m17.2-api-surface-auth-and-shim/task.md
+++ b/docs/plan/milestones/m17-github-api-access/tasks/m17.2-api-surface-auth-and-shim/task.md
@@ -11,7 +11,7 @@ Let a repo-scoped `github` entry inject auth on the `api` surface and export a `
 - Define `api.access: readwrite` as `read` plus POST on the issues and pulls collections and POST and PATCH under each
 - Emit a `bearer` transform on every api rule when `api.auth.secret` is set; default to `on_existing_header: fail`
 - Support `api.auth.client_shim` with a generic `env` kind whose variable name is chosen by the catalog, here
-  `GH_TOKEN`; keep the hint shape generic so `m18.4` can extend it to provider keys
+  `GH_TOKEN`; keep the hint shape generic so `m19.4` can extend it to provider keys
 - Switch api rules to `on_existing_header: replace` only when the shim is present
 - Extend the shell-init consumer so the rendered hint exports `GH_TOKEN` with the placeholder value
 - Keep the sanitized `/run/agentbox/policy.yaml` free of transforms and secret IDs
@@ -98,4 +98,4 @@ Three commits, each leaving the suite green:
 ### Follow-up Items
 
 - `m17.3` re-runs the command matrix against a rebuilt proxy on the host.
-- `m18.4` extends `make_env_hint` to provider variables; no shape change expected.
+- `m19.4` extends `make_env_hint` to provider variables; no shape change expected.

--- a/docs/plan/milestones/m18-dns-egress-controls/milestone.md
+++ b/docs/plan/milestones/m18-dns-egress-controls/milestone.md
@@ -21,8 +21,8 @@ Included:
 - IPv6 egress parity, so the sinkhole cannot be stepped around over a second address family
 - A proxy-side address guard that re-checks the resolved address of an allowed host and refuses private, loopback,
   link-local, and cloud-metadata ranges
-- The same treatment in devcontainer mode, which initializes the firewall through `postStartCommand` rather than the
-  entrypoint
+- The same treatment in devcontainer mode. Its templates set `overrideCommand: false`, so the image entrypoint and
+  `init-firewall.sh` run there too, and the acceptance tests must prove that stays true
 - A documented and reproducible bypass matrix, plus regression tests at the level each control can actually be tested
 - User-facing docs and a note in the image-baked `operating-in-agent-sandbox` skill
 
@@ -48,8 +48,9 @@ Excluded:
 - Environment-variable proxy configuration is advisory; network-level enforcement is what counts. The same reasoning
   applies here. A resolver the agent is merely pointed at is not a control unless the firewall also stops it from
   reaching any other resolver
-- VS Code devcontainers bypass Docker `ENTRYPOINT`, so anything added to firewall init needs the `postStartCommand`
-  path checked too
+- VS Code devcontainers replace the container command by default. The devcontainer templates set
+  `overrideCommand: false` so the image entrypoint runs in both modes; a firewall change that lives only in the
+  entrypoint depends on that setting staying in place
 - Defense in depth works when layers serve different purposes. The firewall restricts where port 53 may go; the
   resolver decides which names exist; the proxy decides which addresses are acceptable. Three layers, three jobs
 - Integration coverage catches wiring that unit tests miss. A resolver that unit-tests correctly can still leave the
@@ -99,8 +100,8 @@ firewall at it.
   static hosts file keyed on container IPs, which change between runs
 - Return `NXDOMAIN` promptly rather than dropping, so a blocked lookup fails fast instead of hanging on a resolver
   timeout the way a silent drop would
-- Point the agent container at the resolver with compose `dns:`, in the managed base layer and in the devcontainer
-  mode layer
+- Point the agent container at the resolver with compose `dns:` in the managed base layer, which both CLI mode and
+  the devcontainer templates consume
 - Add the resolver to the agent's `depends_on` with a health condition, so the agent cannot start before name
   resolution exists
 - Change `init-firewall.sh`: stop extracting and restoring the `127.0.0.11` NAT rules, and allow UDP and TCP port 53
@@ -209,8 +210,9 @@ worth re-scoping before starting.
 - Breaking name resolution breaks everything. Any tool that resolves a hostname directly rather than handing it to the
   proxy stops working. The audit in `m18.1` should list which bundled tools do that before `m18.2` lands, and the
   rollout should be verified against each supported agent image, not just one
-- The devcontainer path has historically diverged from the compose path. A change that lands only in the entrypoint
-  leaves IDE users unprotected and, worse, looks fixed
+- The devcontainer path has historically diverged from the compose path. Today both modes consume the same managed
+  base layer and run the same entrypoint, but only the acceptance tests running in both modes prove that. A control
+  that quietly applies to one mode leaves IDE users unprotected and, worse, looks fixed
 - Adding a service to the compose stack touches `depends_on`, healthchecks, generated templates, the checked-in
   runtime tree, and every `agentbox` command that reasons about services. The blast radius is wider than the size of
   the change suggests

--- a/docs/plan/milestones/m18-dns-egress-controls/milestone.md
+++ b/docs/plan/milestones/m18-dns-egress-controls/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m21 - DNS Egress Controls
+# Milestone: m18 - DNS Egress Controls
 
 ## Goal
 
@@ -55,13 +55,13 @@ Excluded:
 - Integration coverage catches wiring that unit tests miss. A resolver that unit-tests correctly can still leave the
   stack broken if `depends_on` ordering lets the agent start before it is listening
 - The proxy container runs as a non-root user with `cap_drop: ALL`, so binding port 53 needs either
-  `CAP_NET_BIND_SERVICE` or an unprivileged-port sysctl. This shapes the sidecar-versus-in-proxy decision in `m21.2`
+  `CAP_NET_BIND_SERVICE` or an unprivileged-port sysctl. This shapes the sidecar-versus-in-proxy decision in `m18.2`
 - Keep security invariants attached to the construct that enforces them. The address guard belongs where the proxy
   opens the upstream connection, not in documentation telling users to avoid rebinding
 
 ## Tasks
 
-### m21.1-egress-channel-audit
+### m18.1-egress-channel-audit
 
 **Summary:** Prove which outbound channels exist today and turn the result into a reusable bypass matrix.
 
@@ -85,7 +85,7 @@ Excluded:
 - Every later task in this milestone has at least one probe that must flip from escape to blocked
 - No probe depends on a nameserver or domain that outlives the audit
 
-### m21.2-dns-sinkhole
+### m18.2-dns-sinkhole
 
 **Summary:** Give the agent container a resolver that answers compose service names and nothing else, and point the
 firewall at it.
@@ -118,7 +118,7 @@ firewall at it.
 - Both CLI mode and devcontainer mode pass the same assertions
 - `go test ./...` and the proxy suite pass, and generated compose output is covered by the existing template tests
 
-### m21.3-ipv6-egress-parity
+### m18.3-ipv6-egress-parity
 
 **Summary:** Apply the same default-deny posture to IPv6 so the sinkhole cannot be stepped around over a second
 address family.
@@ -130,16 +130,16 @@ address family.
   than silently leaving IPv6 unfiltered
 - Decide whether to disable IPv6 on the compose network instead, and record why the chosen option was picked. If
   IPv6 is disabled rather than filtered, the firewall should assert that it is actually off rather than assume it
-- Add the IPv6 probes from `m21.1` to the firewall self-test
+- Add the IPv6 probes from `m18.1` to the firewall self-test
 
 **Acceptance Criteria:**
 - With IPv6 available on the network, every IPv6 probe from the audit is blocked
 - With IPv6 unavailable, container start still succeeds and the self-test says so explicitly
 - No IPv4 behavior changes
 
-**Dependencies:** `m21.2`, which defines the resolver address the exception points at.
+**Dependencies:** `m18.2`, which defines the resolver address the exception points at.
 
-### m21.4-proxy-address-guard
+### m18.4-proxy-address-guard
 
 **Summary:** Refuse allowed hosts that resolve to addresses the sandbox should never reach.
 
@@ -164,9 +164,9 @@ address family.
 - No change in behavior for hosts that resolve to ordinary public addresses
 - Proxy unit and integration tests cover each refused address class
 
-**Dependencies:** None on the other tasks; can run in parallel with `m21.2` and `m21.3`.
+**Dependencies:** None on the other tasks; can run in parallel with `m18.2` and `m18.3`.
 
-### m21.5-docs-tests-and-agent-guidance
+### m18.5-docs-tests-and-agent-guidance
 
 **Summary:** Document the new boundary, wire the probes into the test suites, and tell agents what changed.
 
@@ -179,7 +179,7 @@ address family.
   and the residual cases that remain open
 - Add a note to the image-baked `operating-in-agent-sandbox` skill so an agent that hits `NXDOMAIN` understands the
   cause instead of retrying or concluding the network is broken
-- Fold the `m21.1` probes into whatever automated coverage they fit: proxy tests for the address guard, the firewall
+- Fold the `m18.1` probes into whatever automated coverage they fit: proxy tests for the address guard, the firewall
   self-test for the in-container assertions, and a documented manual matrix for anything needing a real nameserver
 - Record a decision document for the sinkhole approach, following the numbering in `docs/plan/decisions/`
 
@@ -190,24 +190,24 @@ address family.
   explicit
 - No doc still describes container DNS as unrestricted
 
-**Dependencies:** `m21.2`, `m21.3`, `m21.4`.
+**Dependencies:** `m18.2`, `m18.3`, `m18.4`.
 
 ## Execution Order
 
-1. `m21.1` first. It is cheap, it establishes the baseline, and every later acceptance criterion refers to its matrix.
-2. `m21.2` is the core change and the one most likely to surface surprises in compose wiring and devcontainer mode.
-3. `m21.3` follows `m21.2` because it needs the resolver's address. `m21.4` is independent and can run in parallel
+1. `m18.1` first. It is cheap, it establishes the baseline, and every later acceptance criterion refers to its matrix.
+2. `m18.2` is the core change and the one most likely to surface surprises in compose wiring and devcontainer mode.
+3. `m18.3` follows `m18.2` because it needs the resolver's address. `m18.4` is independent and can run in parallel
    with either.
-4. `m21.5` last, once the behavior is settled.
+4. `m18.5` last, once the behavior is settled.
 
-Decision point after `m21.1`: if the audit shows the bridge gateway exposes a resolver the agent can reach directly,
-the firewall change in `m21.2` grows to narrow rule 5 rather than just redirect port 53, and that is a larger change
+Decision point after `m18.1`: if the audit shows the bridge gateway exposes a resolver the agent can reach directly,
+the firewall change in `m18.2` grows to narrow rule 5 rather than just redirect port 53, and that is a larger change
 worth re-scoping before starting.
 
 ## Risks
 
 - Breaking name resolution breaks everything. Any tool that resolves a hostname directly rather than handing it to the
-  proxy stops working. The audit in `m21.1` should list which bundled tools do that before `m21.2` lands, and the
+  proxy stops working. The audit in `m18.1` should list which bundled tools do that before `m18.2` lands, and the
   rollout should be verified against each supported agent image, not just one
 - The devcontainer path has historically diverged from the compose path. A change that lands only in the entrypoint
   leaves IDE users unprotected and, worse, looks fixed
@@ -234,11 +234,16 @@ worth re-scoping before starting.
   either does not hold
 - An allowed host that resolves to a private, loopback, link-local, or metadata address is refused by the proxy with a
   distinct log event
-- The bypass matrix from `m21.1` re-runs clean, and each entry is covered by an automated test or a documented manual
+- The bypass matrix from `m18.1` re-runs clean, and each entry is covered by an automated test or a documented manual
   procedure
 - Docs, troubleshooting, the agent skill, and a decision record are updated, including the residual gaps
 
 ## Changes
+
+### 2026-09-12: Renumbered from m21 to m18
+
+Inserted ahead of the planned credential and monitoring milestones, none of which have shipped. Provider API-key
+injection moved to `m19`, CLI monitoring to `m20`, and the host credential service to `m21`.
 
 ### 2026-09-12: Created
 
@@ -247,7 +252,3 @@ that Coder Boundary, httpjail, airut, iron-proxy, Docker Sandboxes, and OpenSand
 and that AWS shipped a sandbox network mode with this same hole and had to clarify it after researchers used it. The
 current `init-firewall.sh` deliberately restores Docker's DNS NAT rules, so the channel is open here by design rather
 than by oversight.
-
-Numbered `m21` because `m18` through `m20` are already assigned. Note that
-`docs/plan/research/alternatives.md` proposes a speculative `m21` through `m26` for backend-abstraction work; those
-are proposals in a research document, not created milestones, and should shift by one if they are ever opened.

--- a/docs/plan/milestones/m19-provider-api-key-injection/milestone.md
+++ b/docs/plan/milestones/m19-provider-api-key-injection/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m18 - Provider API-Key Injection
+# Milestone: m19 - Provider API-Key Injection
 
 ## Goal
 
@@ -26,7 +26,7 @@ Excluded:
 - Copilot and Factory primary auth, unless a concrete API-key flow is identified during discovery
 - OAuth, browser login, device-code, refresh-token, and subscription-login flows
 - Request-body mutation, response mutation, or scanning for leaked secret values
-- Local delivery of real credentials into the agent container; residual cases stay with `m20-host-credential-service`
+- Local delivery of real credentials into the agent container; residual cases stay with `m21-host-credential-service`
 - Arbitrary user-authored env exports that are not paired with catalog-owned proxy replacement rules
 - Clients that copy env credentials into query strings, request bodies, signatures, or local auth stores in a way the
   proxy cannot safely replace
@@ -52,7 +52,7 @@ Excluded:
 
 ## Tasks
 
-### m18.1-provider-auth-discovery-and-schema
+### m19.1-provider-auth-discovery-and-schema
 
 **Summary:** Confirm provider request shapes and define the authored service schema for API-key injection.
 
@@ -75,7 +75,7 @@ Excluded:
 **Risks:** Agent CLIs may validate API-key formats before making network requests, which could make a simple fake env var
 insufficient for some clients.
 
-### m18.2-raw-header-transform
+### m19.2-raw-header-transform
 
 **Summary:** Add a generic transform that injects the resolved secret as the complete header value.
 
@@ -96,7 +96,7 @@ insufficient for some clients.
 **Risks:** A too-specific transform name could leak provider assumptions into the generic injection layer. Keep this
 strictly header-value-oriented.
 
-### m18.3-provider-service-catalog-auth
+### m19.3-provider-service-catalog-auth
 
 **Summary:** Teach the service catalog to emit provider-specific request rules and header transforms.
 
@@ -113,12 +113,12 @@ strictly header-value-oriented.
 - Unauthenticated service entries preserve current behavior
 - Renderer tests reject unsupported auth keys and malformed secret IDs
 
-**Dependencies:** `m18.1`, `m18.2`
+**Dependencies:** `m19.1`, `m19.2`
 
 **Risks:** Existing simple service names have broad host expansion. Adding auth must not accidentally inject credentials
 into unrelated login, telemetry, documentation, or update hosts.
 
-### m18.4-generic-env-credential-shim
+### m19.4-generic-env-credential-shim
 
 **Summary:** Extend the generic env shim primitive from `m17.2` to provider API keys and wire them through the catalog.
 
@@ -141,13 +141,13 @@ into unrelated login, telemetry, documentation, or update hosts.
   shell-init consumer contract
 - Authored top-level shim metadata remains rejected
 
-**Dependencies:** `m18.3`, and the env shim primitive from `m17.2`
+**Dependencies:** `m19.3`, and the env shim primitive from `m17.2`
 
 **Risks:** Some clients may inspect key prefixes, copy the fake value into a query string or request body, or use the env
 value to sign requests before making a replaceable HTTP request. Those clients may need a provider-specific shim or may
 remain out of scope.
 
-### m18.5-agent-flow-integration
+### m19.5-agent-flow-integration
 
 **Summary:** Wire and document the supported first-rollout agent flows.
 
@@ -163,12 +163,12 @@ remain out of scope.
 - Each unsupported flow has a clear explanation instead of a silent omission
 - Agent docs no longer recommend putting real supported provider API keys inside the container as the primary path
 
-**Dependencies:** `m18.4`
+**Dependencies:** `m19.4`
 
 **Risks:** Live-provider validation can be hard to run in CI. Prefer mocked proxy integration tests plus documented manual
 smoke checks.
 
-### m18.6-docs-examples-and-tests
+### m19.6-docs-examples-and-tests
 
 **Summary:** Add end-user docs, policy examples, and regression coverage for the full provider API-key injection path.
 
@@ -183,22 +183,22 @@ smoke checks.
 - Tests exercise the examples or share fixtures with them
 - Proxy logs remain useful without leaking secret material
 
-**Dependencies:** `m18.2`, `m18.3`, `m18.4`
+**Dependencies:** `m19.2`, `m19.3`, `m19.4`
 
 **Risks:** Duplicating grammar details across docs can drift. Keep `docs/policy/schema.md` canonical and link to it from
 agent-specific pages.
 
 ## Execution Order
 
-1. Start with `m18.1` to lock the provider surface and avoid implementing a schema around guessed client behavior.
-2. Implement `m18.2` early because Anthropic and Gemini need raw API-key headers.
-3. Add catalog auth in `m18.3`.
-4. Wire providers through the `m17.2` env shim primitive in `m18.4` only after the catalog owns the provider auth rules
+1. Start with `m19.1` to lock the provider surface and avoid implementing a schema around guessed client behavior.
+2. Implement `m19.2` early because Anthropic and Gemini need raw API-key headers.
+3. Add catalog auth in `m19.3`.
+4. Wire providers through the `m17.2` env shim primitive in `m19.4` only after the catalog owns the provider auth rules
    it pairs with.
-5. Validate and document agent flows in `m18.5`.
-6. Finish with the docs, examples, and regression sweep in `m18.6`.
+5. Validate and document agent flows in `m19.5`.
+6. Finish with the docs, examples, and regression sweep in `m19.6`.
 
-`m18.2` can proceed in parallel with part of `m18.1` once the raw-header need is confirmed. `m18.5` should not start until
+`m19.2` can proceed in parallel with part of `m19.1` once the raw-header need is confirmed. `m19.5` should not start until
 the shim behavior exists.
 
 ## Risks
@@ -224,6 +224,12 @@ the shim behavior exists.
 - The roadmap treats GitHub REST wrapper, CLI monitoring, and host credential service as later milestones.
 
 ## Changes
+
+### 2026-09-12: Renumbered from m18 to m19
+
+DNS egress controls took `m18` so the security work ships before the credential work. Nothing in this
+milestone has been implemented, so the move is a rename only. The historical entry below records the earlier
+swap with `m17` and is left as written.
 
 ### 2026-09-06: Renumbered from m17 to m18
 

--- a/docs/plan/milestones/m21-dns-egress-controls/milestone.md
+++ b/docs/plan/milestones/m21-dns-egress-controls/milestone.md
@@ -1,0 +1,253 @@
+# Milestone: m21 - DNS Egress Controls
+
+## Goal
+
+Close the last undeclared outbound channel in the sandbox. Today every TCP connection must go through the proxy, but
+name resolution is unrestricted: the agent container resolves arbitrary names through Docker's embedded resolver at
+`127.0.0.11`, which forwards recursively to the host's resolver and out to the internet. An attacker-controlled
+authoritative nameserver sees every query name, so a query for `<base32-of-secret>.exfil.example` leaks data without
+the agent ever opening a socket the firewall would block. TXT answers make it bidirectional.
+
+After this milestone, a name the policy does not need does not resolve, and an allowed name cannot be pointed at an
+address the proxy should refuse.
+
+## Scope
+
+Included:
+
+- A sinkhole resolver for the agent container that answers compose service names and returns `NXDOMAIN` for
+  everything else
+- Firewall changes so port 53 reaches only that resolver, replacing today's restoration of Docker's DNS NAT rules
+- IPv6 egress parity, so the sinkhole cannot be stepped around over a second address family
+- A proxy-side address guard that re-checks the resolved address of an allowed host and refuses private, loopback,
+  link-local, and cloud-metadata ranges
+- The same treatment in devcontainer mode, which initializes the firewall through `postStartCommand` rather than the
+  entrypoint
+- A documented and reproducible bypass matrix, plus regression tests at the level each control can actually be tested
+- User-facing docs and a note in the image-baked `operating-in-agent-sandbox` skill
+
+Excluded:
+
+- A policy surface for DNS. Resolvable names stay derived from the compose stack, not authored. If a user needs a name
+  resolved, the proxy resolves it on their behalf; the agent never needs to
+- DNS-over-HTTPS to an already-allowed host. A host on the allowlist that also serves DoH is a smaller case of the
+  allowed-host exfiltration problem this milestone does not try to solve. Recorded as a risk
+- Response-content inspection or any attempt to detect encoded data in query names. This milestone removes the
+  channel rather than policing it
+- Egress controls for the proxy container itself, which must resolve allowed hosts
+- Blocking the Docker bridge gateway wholesale. Rule 5 of `init-firewall.sh` allows the host network in both
+  directions because that is how the proxy sidecar is reached; narrowing it is a separate change
+- SNI and Host alignment checks, redirect re-authorization, and the other L7 defenses listed in the alternatives
+  research. Those belong with a request-inspection milestone
+
+## Applicable Learnings
+
+- "iptables rules must preserve Docker's internal DNS resolution (127.0.0.11 NAT rules) or container DNS breaks" is
+  the first line of `learnings.md`, and it is exactly what this milestone reverses. The replacement has to resolve
+  compose service names itself, because the agent still needs `proxy` to resolve for `HTTPS_PROXY` to work
+- Environment-variable proxy configuration is advisory; network-level enforcement is what counts. The same reasoning
+  applies here. A resolver the agent is merely pointed at is not a control unless the firewall also stops it from
+  reaching any other resolver
+- VS Code devcontainers bypass Docker `ENTRYPOINT`, so anything added to firewall init needs the `postStartCommand`
+  path checked too
+- Defense in depth works when layers serve different purposes. The firewall restricts where port 53 may go; the
+  resolver decides which names exist; the proxy decides which addresses are acceptable. Three layers, three jobs
+- Integration coverage catches wiring that unit tests miss. A resolver that unit-tests correctly can still leave the
+  stack broken if `depends_on` ordering lets the agent start before it is listening
+- The proxy container runs as a non-root user with `cap_drop: ALL`, so binding port 53 needs either
+  `CAP_NET_BIND_SERVICE` or an unprivileged-port sysctl. This shapes the sidecar-versus-in-proxy decision in `m21.2`
+- Keep security invariants attached to the construct that enforces them. The address guard belongs where the proxy
+  opens the upstream connection, not in documentation telling users to avoid rebinding
+
+## Tasks
+
+### m21.1-egress-channel-audit
+
+**Summary:** Prove which outbound channels exist today and turn the result into a reusable bypass matrix.
+
+**Scope:**
+- Run each candidate channel from inside a current sandbox and record whether it escapes: `getaddrinfo` through
+  `127.0.0.11`, direct queries to the Docker bridge gateway, direct queries to a public resolver, TCP/53, DNS-over-TLS
+  on 853, DNS-over-HTTPS to an allowed host, and IPv6 equivalents of each
+- Confirm the exfiltration path end to end against a nameserver under our control, so the finding is a demonstration
+  and not an inference
+- Record whether Docker's embedded resolver is reachable over TCP as well as UDP, and what it does with `TXT`, `NULL`,
+  and long label chains
+- Check whether the Colima VM's bridge gateway runs a resolver the agent can reach directly, since the host network is
+  allowed in both directions
+- Determine whether the compose network has IPv6 enabled by default on the supported platforms, and what
+  `init-firewall.sh` leaves unprotected when it does
+- Package the probes as a script that can be re-run after each subsequent task
+
+**Acceptance Criteria:**
+- A checked-in matrix lists every probe, the observed result before any change, and the expected result after
+- The demonstration of the query-name channel is reproducible by a second person from the write-up
+- Every later task in this milestone has at least one probe that must flip from escape to blocked
+- No probe depends on a nameserver or domain that outlives the audit
+
+### m21.2-dns-sinkhole
+
+**Summary:** Give the agent container a resolver that answers compose service names and nothing else, and point the
+firewall at it.
+
+**Scope:**
+- Decide between a dedicated resolver sidecar and adding a resolver to the existing proxy container, and record the
+  decision. The proxy container currently runs as a non-root user with all capabilities dropped, so binding port 53
+  there requires a capability or a sysctl; a sidecar keeps that boundary intact at the cost of one more service
+- Serve only the names the stack needs. Forward the compose service names to the container's own embedded resolver so
+  service discovery keeps working through Docker's IPAM, and answer `NXDOMAIN` for every other name. Do not use a
+  static hosts file keyed on container IPs, which change between runs
+- Return `NXDOMAIN` promptly rather than dropping, so a blocked lookup fails fast instead of hanging on a resolver
+  timeout the way a silent drop would
+- Point the agent container at the resolver with compose `dns:`, in the managed base layer and in the devcontainer
+  mode layer
+- Add the resolver to the agent's `depends_on` with a health condition, so the agent cannot start before name
+  resolution exists
+- Change `init-firewall.sh`: stop extracting and restoring the `127.0.0.11` NAT rules, and allow UDP and TCP port 53
+  only to the resolver's address. Keep the existing positive and negative self-tests and add a DNS pair to them, one
+  name that must resolve and one that must not
+- Leave the proxy container's own resolution untouched
+- Regenerate this repo's checked-in `.agent-sandbox/` runtime so local development exercises the new stack
+
+**Acceptance Criteria:**
+- From the agent container, a lookup of a random label under a domain we control returns `NXDOMAIN` and no query
+  reaches that domain's nameserver
+- `curl -x http://proxy:8080 https://github.com` still succeeds, and an unlisted host still returns the proxy 403
+- A direct query to a public resolver and a direct query to the bridge gateway both fail
+- The firewall self-test fails the container start if either DNS assertion does not hold
+- Both CLI mode and devcontainer mode pass the same assertions
+- `go test ./...` and the proxy suite pass, and generated compose output is covered by the existing template tests
+
+### m21.3-ipv6-egress-parity
+
+**Summary:** Apply the same default-deny posture to IPv6 so the sinkhole cannot be stepped around over a second
+address family.
+
+**Scope:**
+- Extend `init-firewall.sh` to program `ip6tables` alongside `iptables`: default-deny policies, loopback, the host
+  network, established and related, and the same port 53 exception to the resolver
+- Handle the case where the kernel or image lacks `ip6tables` support, failing closed with a clear message rather
+  than silently leaving IPv6 unfiltered
+- Decide whether to disable IPv6 on the compose network instead, and record why the chosen option was picked. If
+  IPv6 is disabled rather than filtered, the firewall should assert that it is actually off rather than assume it
+- Add the IPv6 probes from `m21.1` to the firewall self-test
+
+**Acceptance Criteria:**
+- With IPv6 available on the network, every IPv6 probe from the audit is blocked
+- With IPv6 unavailable, container start still succeeds and the self-test says so explicitly
+- No IPv4 behavior changes
+
+**Dependencies:** `m21.2`, which defines the resolver address the exception points at.
+
+### m21.4-proxy-address-guard
+
+**Summary:** Refuse allowed hosts that resolve to addresses the sandbox should never reach.
+
+**Scope:**
+- At the point where the proxy opens an upstream connection, check the resolved address against a deny set: loopback,
+  private ranges, link-local including `169.254.169.254`, unique-local and link-local IPv6, and the Docker bridge
+  network the sandbox itself runs on
+- Apply the check to both the CONNECT fast path and the request path, so a host-only rule is covered as well as a
+  request-aware one
+- Emit a distinct structured decision event so a refusal is distinguishable from a policy miss in the logs, and
+  return a proxy error body that names the reason
+- Decide whether to pin the connection to the checked answer or to re-check after connect, and record the residual
+  time-of-check risk either way
+- Add an escape hatch only if the existing tests need one for loopback rebinding in the integration harness, and keep
+  it out of the authored policy surface
+
+**Acceptance Criteria:**
+- A host on the allowlist whose DNS answer is a private or link-local address is refused, with a log event naming
+  the address class
+- The existing integration harness, which rebinds rendered hosts onto loopback, still passes, either through the
+  documented escape hatch or by an explicit test-only configuration
+- No change in behavior for hosts that resolve to ordinary public addresses
+- Proxy unit and integration tests cover each refused address class
+
+**Dependencies:** None on the other tasks; can run in parallel with `m21.2` and `m21.3`.
+
+### m21.5-docs-tests-and-agent-guidance
+
+**Summary:** Document the new boundary, wire the probes into the test suites, and tell agents what changed.
+
+**Scope:**
+- Update `docs/policy/schema.md` to state plainly that DNS is not policy-controlled and why, so nobody goes looking
+  for a `dns:` key
+- Add a troubleshooting entry for the failure this will actually produce: a tool that resolves names itself now gets
+  `NXDOMAIN` instead of a connection error, and the fix is to route it through the proxy
+- Document the threat in `docs/` in one short section: what DNS exfiltration is, what the sandbox now does about it,
+  and the residual cases that remain open
+- Add a note to the image-baked `operating-in-agent-sandbox` skill so an agent that hits `NXDOMAIN` understands the
+  cause instead of retrying or concluding the network is broken
+- Fold the `m21.1` probes into whatever automated coverage they fit: proxy tests for the address guard, the firewall
+  self-test for the in-container assertions, and a documented manual matrix for anything needing a real nameserver
+- Record a decision document for the sinkhole approach, following the numbering in `docs/plan/decisions/`
+
+**Acceptance Criteria:**
+- A user who hits the new failure mode can diagnose it from the troubleshooting entry alone
+- The decision record states the alternatives considered and why a policy-driven resolver was rejected
+- Every control in this milestone has either automated coverage or a documented manual procedure, and the split is
+  explicit
+- No doc still describes container DNS as unrestricted
+
+**Dependencies:** `m21.2`, `m21.3`, `m21.4`.
+
+## Execution Order
+
+1. `m21.1` first. It is cheap, it establishes the baseline, and every later acceptance criterion refers to its matrix.
+2. `m21.2` is the core change and the one most likely to surface surprises in compose wiring and devcontainer mode.
+3. `m21.3` follows `m21.2` because it needs the resolver's address. `m21.4` is independent and can run in parallel
+   with either.
+4. `m21.5` last, once the behavior is settled.
+
+Decision point after `m21.1`: if the audit shows the bridge gateway exposes a resolver the agent can reach directly,
+the firewall change in `m21.2` grows to narrow rule 5 rather than just redirect port 53, and that is a larger change
+worth re-scoping before starting.
+
+## Risks
+
+- Breaking name resolution breaks everything. Any tool that resolves a hostname directly rather than handing it to the
+  proxy stops working. The audit in `m21.1` should list which bundled tools do that before `m21.2` lands, and the
+  rollout should be verified against each supported agent image, not just one
+- The devcontainer path has historically diverged from the compose path. A change that lands only in the entrypoint
+  leaves IDE users unprotected and, worse, looks fixed
+- Adding a service to the compose stack touches `depends_on`, healthchecks, generated templates, the checked-in
+  runtime tree, and every `agentbox` command that reasons about services. The blast radius is wider than the size of
+  the change suggests
+- An allowed host that also serves DNS-over-HTTPS reopens a query channel at a smaller scale. This milestone does not
+  close it, and the docs should say so rather than overclaim
+- The address guard has an unavoidable time-of-check-to-time-of-use gap unless the connection is pinned to the
+  checked answer. Whichever option is chosen, the residual risk belongs in the decision record
+- Chasing DNS can look like security theater next to the larger allowed-host channel. The honest framing is that this
+  closes a channel that exists regardless of policy, at low cost, and it is table stakes in comparable tools; it does
+  not reduce what an allowed host can carry
+- `NXDOMAIN` for an unexpected name is a new, unfamiliar failure mode. Without the skill note and troubleshooting
+  entry, agents will burn turns misdiagnosing it
+
+## Definition of Done
+
+- A lookup from the agent container for any name the stack does not need returns `NXDOMAIN`, and no query for it
+  leaves the host
+- Port 53 from the agent container reaches only the sandbox resolver, over IPv4 and IPv6, in both CLI and devcontainer
+  mode
+- The firewall self-test asserts both the positive and negative DNS cases at container start and fails the start if
+  either does not hold
+- An allowed host that resolves to a private, loopback, link-local, or metadata address is refused by the proxy with a
+  distinct log event
+- The bypass matrix from `m21.1` re-runs clean, and each entry is covered by an automated test or a documented manual
+  procedure
+- Docs, troubleshooting, the agent skill, and a decision record are updated, including the residual gaps
+
+## Changes
+
+### 2026-09-12: Created
+
+Opened after the DNS channel came up while reviewing `docs/plan/research/alternatives.md`. The research pass found
+that Coder Boundary, httpjail, airut, iron-proxy, Docker Sandboxes, and OpenSandbox all sinkhole or intercept DNS,
+and that AWS shipped a sandbox network mode with this same hole and had to clarify it after researchers used it. The
+current `init-firewall.sh` deliberately restores Docker's DNS NAT rules, so the channel is open here by design rather
+than by oversight.
+
+Numbered `m21` because `m18` through `m20` are already assigned. Note that
+`docs/plan/research/alternatives.md` proposes a speculative `m21` through `m26` for backend-abstraction work; those
+are proposals in a research document, not created milestones, and should shift by one if they are ever opened.

--- a/docs/plan/milestones/m21-host-credential-service/milestone.md
+++ b/docs/plan/milestones/m21-host-credential-service/milestone.md
@@ -1,4 +1,4 @@
-# Milestone: m20 - Host Credential Service
+# Milestone: m21 - Host Credential Service
 
 Run a narrower host-side credential service for auth flows that cannot be handled cleanly by `m15-proxy-secret-injection`. The helper keeps credentials off disk inside the container, but unlike proxy injection it does allow the client to receive credential material when that is unavoidable.
 

--- a/docs/plan/milestones/m6-cli/milestone.md
+++ b/docs/plan/milestones/m6-cli/milestone.md
@@ -25,7 +25,7 @@ Give developers a single command-line tool that handles the full lifecycle of an
 **Excluded:**
 - Go rewrite (m13)
 - Fine-grained proxy rules (m14)
-- Interactive monitoring/unblocking (now tracked for m19)
+- Interactive monitoring/unblocking (now tracked for m20)
 
 ## Applicable Learnings
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -15,7 +15,7 @@ Two runtime modes are supported:
 
 **Devcontainer mode** (`.devcontainer/`):
 - For VS Code users
-- Firewall initialized via `postStartCommand`
+- Firewall initialized by the image entrypoint; `overrideCommand: false` keeps VS Code from replacing the command
 - Volumes and env vars in devcontainer.json
 
 **Compose mode** (`docker-compose.yml`):
@@ -34,10 +34,10 @@ Image hierarchy established in `images/` (base + claude).
 ## Architecture Decisions
 
 **Runtime modes:**
-- **Devcontainer mode**: For VS Code users. Firewall initialized via `postStartCommand` (VS Code bypasses Docker entrypoints).
+- **Devcontainer mode**: For VS Code users. Firewall initialized by the same entrypoint script; `overrideCommand: false` stops VS Code from replacing the container command.
 - **Compose mode**: For CLI/standalone users. Firewall initialized via entrypoint script with idempotent check.
 
-Both modes use the same images; they differ only in how firewall initialization is triggered.
+Both modes use the same images and run the same entrypoint; they differ only in which compose layers each mode loads.
 
 **Network enforcement approach:**
 - Phase 1: iptables-based (simpler, already working)

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -302,9 +302,28 @@ the proxy and agent instructions for the common workflows. Replaces the earlier 
 - A per-capability policy surface mirroring GitHub's token permissions
 
 **Dependencies:** m14 (repo/path-aware policy matching), m15 (header injection and renderer-owned shim). Builds the
-generic env shim primitive that m18 reuses.
+generic env shim primitive that m19 reuses.
 
-### m18-provider-api-key-injection
+### m18-dns-egress-controls
+
+Close the last undeclared outbound channel. All TCP egress already goes through the proxy, but name resolution is
+unrestricted, so query names sent to an attacker-controlled nameserver carry data out without opening a socket the
+firewall would block.
+
+**Goals:**
+- A sinkhole resolver that answers compose service names and returns `NXDOMAIN` for everything else
+- Port 53 from the agent container restricted to that resolver, over IPv4 and IPv6
+- Proxy-side refusal of allowed hosts that resolve to loopback, private, link-local, or metadata addresses
+- Parity between CLI and devcontainer modes, with the assertions enforced by the firewall self-test
+
+**Out of scope:**
+- A `dns:` policy surface; resolvable names stay derived from the compose stack
+- DNS-over-HTTPS to an already-allowed host, which is a case of the broader allowed-host channel
+- Narrowing the host-network rule that makes the proxy sidecar reachable
+
+**Dependencies:** m3 (proxy is the enforcement point), m14 (request-aware matching for the address guard)
+
+### m19-provider-api-key-injection
 
 Extend the `m15` proxy-side credential model from GitHub Git auth to model-provider API-key traffic, so current agents
 can call supported provider APIs without the real API key being readable inside the agent container.
@@ -330,7 +349,7 @@ can call supported provider APIs without the real API key being readable inside 
 **Dependencies:** m15 (proxy-side secret injection), m14 (request-phase matching and transforms), m17 (generic env
 shim primitive)
 
-### m19-cli-monitoring
+### m20-cli-monitoring
 
 CLI tools for monitoring proxy activity and managing policy interactively.
 
@@ -342,7 +361,7 @@ CLI tools for monitoring proxy activity and managing policy interactively.
 
 **Dependencies:** m13 (Go CLI), m14 (fine-grained proxy and hot reload)
 
-### m20-host-credential-service
+### m21-host-credential-service
 
 Add a narrower, secondary credential path for tools and auth flows that cannot be handled cleanly by proxy-side injection.
 
@@ -353,25 +372,6 @@ Add a narrower, secondary credential path for tools and auth flows that cannot b
 - Integrate the helper lifecycle with the Go CLI
 
 **Dependencies:** m13 (Go CLI manages service lifecycle), m15 (primary proxy-based credential path defined first)
-
-### m21-dns-egress-controls
-
-Close the last undeclared outbound channel. All TCP egress already goes through the proxy, but name resolution is
-unrestricted, so query names sent to an attacker-controlled nameserver carry data out without opening a socket the
-firewall would block.
-
-**Goals:**
-- A sinkhole resolver that answers compose service names and returns `NXDOMAIN` for everything else
-- Port 53 from the agent container restricted to that resolver, over IPv4 and IPv6
-- Proxy-side refusal of allowed hosts that resolve to loopback, private, link-local, or metadata addresses
-- Parity between CLI and devcontainer modes, with the assertions enforced by the firewall self-test
-
-**Out of scope:**
-- A `dns:` policy surface; resolvable names stay derived from the compose stack
-- DNS-over-HTTPS to an already-allowed host, which is a case of the broader allowed-host channel
-- Narrowing the host-network rule that makes the proxy sidecar reachable
-
-**Dependencies:** m3 (proxy is the enforcement point), m14 (request-aware matching for the address guard)
 
 ## Decisions
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -354,6 +354,25 @@ Add a narrower, secondary credential path for tools and auth flows that cannot b
 
 **Dependencies:** m13 (Go CLI manages service lifecycle), m15 (primary proxy-based credential path defined first)
 
+### m21-dns-egress-controls
+
+Close the last undeclared outbound channel. All TCP egress already goes through the proxy, but name resolution is
+unrestricted, so query names sent to an attacker-controlled nameserver carry data out without opening a socket the
+firewall would block.
+
+**Goals:**
+- A sinkhole resolver that answers compose service names and returns `NXDOMAIN` for everything else
+- Port 53 from the agent container restricted to that resolver, over IPv4 and IPv6
+- Proxy-side refusal of allowed hosts that resolve to loopback, private, link-local, or metadata addresses
+- Parity between CLI and devcontainer modes, with the assertions enforced by the firewall self-test
+
+**Out of scope:**
+- A `dns:` policy surface; resolvable names stay derived from the compose stack
+- DNS-over-HTTPS to an already-allowed host, which is a case of the broader allowed-host channel
+- Narrowing the host-network rule that makes the proxy sidecar reachable
+
+**Dependencies:** m3 (proxy is the enforcement point), m14 (request-aware matching for the address guard)
+
 ## Decisions
 
 1. **Policy format**: YAML with domain-only granularity for m1-m4. Path/method filtering deferred to future work.

--- a/docs/plan/research/alternatives.md
+++ b/docs/plan/research/alternatives.md
@@ -1223,7 +1223,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - The WireGuard plus shared-namespace design adds startup ordering and networking complexity without solving the separate IDE control plane that the repo itself documents
   - The packaged workflow is devcontainer- and Claude-shaped, not a neutral multi-agent control plane
 - Open questions:
-  - Could proxy-side secret substitution cover enough of `m20-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
+  - Could proxy-side secret substitution cover enough of `m21-host-credential-service` to make the helper path strictly secondary, or are there still important workflows that require local credential delivery?
   - Do we need transparent capture enough to justify the added WireGuard complexity, given the current explicit proxy plus firewall design already blocks direct egress?
   - Should any sandcat-inspired work land as devcontainer-only hardening rather than as part of the core backend contract?
 - Verdict: `useful supporting reference`
@@ -1315,7 +1315,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - Remote execution or gateway fleet support: no
 - Key strengths:
   - This is a genuine stronger-isolation reference, not just a container-plus-proxy variant
-  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m22-backend-interface`
+  - The split between host policy engine, host VFS service, and microVM runtime is directly relevant to `m23-backend-interface`
   - Network policy is materially richer than our current baseline: host allow-listing, path and method matching, request or response mutation, runtime allow-list edits, and offline mode
   - The VFS layer is more interesting than it first appears; it creates a host-side place to enforce or observe filesystem operations without bind-mounting the host repo directly into the guest
   - Lifecycle persistence and reconciliation are stronger than most research repos in this space
@@ -1336,7 +1336,7 @@ When reviewing an item, capture whether it implements any of these primitives:
 
 - Worth bringing into the vision:
   - a real microVM-backed stronger-isolation backend candidate
-  - host-side VFS and exec control-plane separation as input to `m22-backend-interface`
+  - host-side VFS and exec control-plane separation as input to `m23-backend-interface`
   - richer HTTP policy concepts for `m14`, especially method and path matching plus response shaping
   - lifecycle persistence and explicit garbage-collection or reconcile workflows for leaked sandbox resources
 - Probably not worth bringing in as-is:
@@ -1345,7 +1345,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - assuming a FUSE or VFS workspace model is the right default for local developer ergonomics before measuring it against a shared mount model
 - Research consequence:
   - Treat `matchlock` as a leading reference for the optional stronger-isolation backend and for backend-interface design, not as an argument to replace the current local default before we have comparative measurements
-  - It should directly inform `m22-backend-interface` and `m24-runtime-spikes-vm`
+  - It should directly inform `m23-backend-interface` and `m25-runtime-spikes-vm`
 
 ### strongdm/leash
 
@@ -1445,7 +1445,7 @@ When reviewing an item, capture whether it implements any of these primitives:
   - accepting materially different network semantics on macOS and Linux under one policy name without very clear degradation rules
 - Research consequence:
   - Treat `leash` as a leading reference for policy IR, rollout modes, and observability, not as proof that a container boundary alone is sufficient for the project's stronger-isolation backend
-  - It should inform `m21-capability-model` and `m22-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
+  - It should inform `m22-capability-model` and `m23-backend-interface`, especially around event schema, policy compilation, and backend capability degradation
 
 ## Research backlog: commercial products
 
@@ -1656,15 +1656,15 @@ Deliverable:
 
 ## Proposed milestones
 
-### m21-capability-model
+### m22-capability-model
 
 Define the threat model, capability matrix, and backend scorecard.
 
-### m22-backend-interface
+### m23-backend-interface
 
 Define a backend-agnostic runner contract, event schema, and policy compiler boundary.
 
-### m23-runtime-spikes-lite
+### m24-runtime-spikes-lite
 
 Build and compare:
 
@@ -1672,21 +1672,21 @@ Build and compare:
 - OS-native backend
 - gVisor backend
 
-### m24-runtime-spikes-vm
+### m25-runtime-spikes-vm
 
 Build and compare:
 
 - Kata backend
 - One heavy-isolation backend such as Firecracker or full VM
 
-### m25-kubernetes-track
+### m26-kubernetes-track
 
 Only if earlier milestones justify it:
 
 - KubeVirt or Kata on Kubernetes
 - Cilium or similar for L7 policy and observability experiments
 
-### m26-decision-and-integration
+### m27-decision-and-integration
 
 Choose:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,7 +132,7 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 
 - Ship stock `gh` in the base image and use `gh api` for repo-scoped REST calls; no custom wrapper
 - Add `auth` on the `api` surface of repo-scoped `github` policy entries, with a `GH_TOKEN` shim so the token never
-  enters the agent container; this introduces the generic env shim primitive that `m18` reuses
+  enters the agent container; this introduces the generic env shim primitive that `m19` reuses
 - Keep repo identity in request URLs so `m14` policies constrain access to one repo; GraphQL-backed `gh` commands stay
   blocked
 - Define `readwrite` as a fixed allowlist of issue and pull-request writes; no write reaches administration, webhook,
@@ -140,7 +140,16 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Validate and document which stock `gh` commands work under repo-scoped rules
 - Add agent instructions for the most common workflows to the `operating-in-agent-sandbox` skill
 
-## m18: Provider API-key injection (planned)
+## m18: DNS egress controls (planned)
+
+- Replace Docker's embedded resolver with a sinkhole that answers compose service names and returns `NXDOMAIN` for
+  everything else, closing query-name exfiltration
+- Restrict port 53 from the agent container to that resolver, over IPv4 and IPv6, in both CLI and devcontainer mode
+- Refuse allowed hosts that resolve to loopback, private, link-local, or cloud-metadata addresses at the proxy
+- Keep DNS out of the authored policy surface; the proxy resolves on the agent's behalf
+- Document the residual cases, including DNS-over-HTTPS to an already-allowed host
+
+## m19: Provider API-key injection (planned)
 
 - Extend proxy-side secret injection from GitHub Git auth to model-provider API-key traffic
 - Add raw-header injection for provider headers whose value is the secret itself
@@ -150,26 +159,17 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Support Codex, Claude API-key mode, Gemini API-key mode, and provider-backed Pi/OpenCode flows where practical
 - Explicitly exclude OAuth, browser login, device-code, subscription-login, and helper-protocol flows
 
-## m19: CLI monitoring and policy management (planned)
+## m20: CLI monitoring and policy management (planned)
 
 - Filtered log view for blocked requests
 - Interactive unblock workflow
 - Integration with hot reload for immediate policy updates
 - UI approach TBD (filtered stream, TUI, or hybrid)
 
-## m20: Host credential service (planned)
+## m21: Host credential service (planned)
 
 - Secondary credential path for flows that cannot be handled by proxy injection
 - Host-side service bridging container to native credential store or helper backend
 - Container shim implements a helper protocol for clients that must receive credentials locally
 - Keep credentials off disk inside the container even when direct injection is not viable
 - Integrated into agentbox CLI lifecycle
-
-## m21: DNS egress controls (planned)
-
-- Replace Docker's embedded resolver with a sinkhole that answers compose service names and returns `NXDOMAIN` for
-  everything else, closing query-name exfiltration
-- Restrict port 53 from the agent container to that resolver, over IPv4 and IPv6, in both CLI and devcontainer mode
-- Refuse allowed hosts that resolve to loopback, private, link-local, or cloud-metadata addresses at the proxy
-- Keep DNS out of the authored policy surface; the proxy resolves on the agent's behalf
-- Document the residual cases, including DNS-over-HTTPS to an already-allowed host

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -164,3 +164,12 @@ Detailed project plan can be found in [plan/project.md](./plan/project.md) and r
 - Container shim implements a helper protocol for clients that must receive credentials locally
 - Keep credentials off disk inside the container even when direct injection is not viable
 - Integrated into agentbox CLI lifecycle
+
+## m21: DNS egress controls (planned)
+
+- Replace Docker's embedded resolver with a sinkhole that answers compose service names and returns `NXDOMAIN` for
+  everything else, closing query-name exfiltration
+- Restrict port 53 from the agent container to that resolver, over IPv4 and IPv6, in both CLI and devcontainer mode
+- Refuse allowed hosts that resolve to loopback, private, link-local, or cloud-metadata addresses at the proxy
+- Keep DNS out of the authored policy surface; the proxy resolves on the agent's behalf
+- Document the residual cases, including DNS-over-HTTPS to an already-allowed host


### PR DESCRIPTION
## Summary

Plans the DNS egress controls milestone and slots it in as m18 ahead of the other planned milestones.

All TCP egress already goes through the proxy, but name resolution is unrestricted. The agent resolves arbitrary names through Docker's embedded resolver, which forwards recursively, so query names carry data to an attacker-controlled nameserver without opening a socket the firewall would block.

The milestone plans five tasks:

- Audit the resolution channels and build a bypass matrix
- Replace Docker's resolver with a sinkhole that answers compose service names only, and restrict port 53 to it
- Extend the same posture to IPv6
- Refuse allowed hosts that resolve to private or metadata addresses at the proxy
- Document and test

## Renumbering

None of the planned milestones have shipped, so the move is a rename:

- DNS egress controls becomes m18
- Provider API-key injection moves from m18 to m19
- CLI monitoring moves from m19 to m20
- Host credential service moves from m20 to m21

Forward references are updated in the decision records, the m6, m14, m15, m16, and m17 plans, the roadmap, and the project plan. Dated Changes entries that record the earlier m17/m18 swap are left as written since they are history rather than current state.

## Scope

Planning docs only under `docs/plan/` and `docs/roadmap.md`. No code, template, or image changes.